### PR TITLE
Making the type Name.domain_name abstract

### DIFF
--- a/lib/loader.ml
+++ b/lib/loader.ml
@@ -366,9 +366,9 @@ type parserstate = {
   mutable paren: int;
   mutable filename: string;
   mutable lineno: int;
-  mutable origin: string list;
+  mutable origin: domain_name;
   mutable ttl: int32;
-  mutable owner: string list;
+  mutable owner: domain_name;
 }
 
 let new_state () = {
@@ -377,8 +377,8 @@ let new_state () = {
   filename = "";
   lineno = 1;
   ttl = Int32.of_int 3600;
-  origin = [];
-  owner = [];
+  origin = empty;
+  owner = empty;
 }
 
 let state = new_state ()

--- a/lib/loader.mli
+++ b/lib/loader.mli
@@ -86,8 +86,8 @@ type parserstate = {
     mutable paren: int;
     mutable filename: string;
     mutable lineno: int;
-    mutable origin: string list;
+    mutable origin: domain_name;
     mutable ttl: int32;
-    mutable owner: string list;
+    mutable owner: domain_name;
   }
 val state : parserstate

--- a/lib/name.ml
+++ b/lib/name.ml
@@ -35,9 +35,15 @@ module Map = Map.Make(struct
       | i -> i
 end)
 
-let domain_name_to_string dn = String.concat "." dn
+let empty = []
+let append = (@)
+let cons x xs = (String.lowercase x) :: xs
+let to_string_list dn = dn
+let of_string_list = List.map String.lowercase
+
+let domain_name_to_string = String.concat "."
 let string_to_domain_name (s:string) : domain_name =
-  Re_str.split (Re_str.regexp "\\.") s
+  Re_str.split (Re_str.regexp "\\.") (String.lowercase s)
 
 let for_reverse ip =
   (".arpa.in-addr."^Ipaddr.V4.to_string ip) |> string_to_domain_name |> List.rev
@@ -204,3 +210,4 @@ let rec dnssec_compare a b =
           else
             compare (String.length a) (String.length b)
         )
+let dnssec_compare_str = dnssec_compare

--- a/lib/name.mli
+++ b/lib/name.mli
@@ -1,6 +1,7 @@
 (*
  * Copyright (c) 2011 Richard Mortier <mort@cantab.net>
  * Copyright (c) 2011 Anil Madhavapeddy <anil@recoil.org>
+ * Copyright (c) 2015 Heidi Howard <hh360@cam.ac.uk>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -27,12 +28,27 @@ open Cstruct
 type label
 
 (** Domain name, as a list of strings. *)
-type domain_name = string list
+type domain_name
 
 (** Domain name map *)
 module Map: Map.S with type key = domain_name
 
-(** Render a {! domain_name} to a simple string. *)
+(** Create empty {! domain_name}. *)
+val empty: domain_name
+
+(** Render a {! domain_name} to a {! string} list. *)
+val to_string_list : domain_name -> string list
+
+(** Convert a standard domain {! string} list to a {! domain_name}. *)
+val of_string_list : string list -> domain_name
+
+(** Append two {! domain_name} values. *)
+val append: domain_name -> domain_name -> domain_name
+
+(** Concatenate a {! string} onto a {! domain_name}. *) 
+val cons: string -> domain_name -> domain_name
+
+(** Render a {! domain_name} to a simple {! string}. *)
 val domain_name_to_string : domain_name -> string
 
 (** Convert a standard domain {! string} to a {! domain_name}. *)
@@ -74,3 +90,4 @@ type key = string
 val canon2key : domain_name -> key
 
 val dnssec_compare : domain_name -> domain_name -> int
+val dnssec_compare_str : string list -> string list -> int

--- a/lib/packet.ml
+++ b/lib/packet.ml
@@ -1223,9 +1223,10 @@ let parse_rdata names base t cls ttl buf =
           ) else
             compare a_f b_f
     | MB a, MB b  | MD a, MD b | MF a, MF b | MG a, MG b
-    | MR a, MR b | NS a, NS b | PTR a, PTR b | TXT a, TXT b
+    | MR a, MR b | NS a, NS b | PTR a, PTR b 
     | CNAME a, CNAME b ->
         Name.dnssec_compare a b
+    | TXT a, TXT b -> Name.dnssec_compare_str a b
 (*| DS (tag, alg, digest, key) ->
   | HINFO (cpu,os) ->
   | ISDN (a,sa) ->

--- a/lib/query.ml
+++ b/lib/query.ml
@@ -78,7 +78,7 @@ let create ?(dnssec=false) ~id q_class q_type q_name =
   let additionals =
     if dnssec then
       [ ( {
-        name=[]; cls=RR_IN; flush=false; ttl=0l;
+        name=Name.empty; cls=RR_IN; flush=false; ttl=0l;
         rdata=(EDNS0(1500, 0, true, []));} ) ]
     else
       []
@@ -472,7 +472,7 @@ let answer_multiple ?(dnssec=false) ?(mdns=false) ?(filter=null_filter) ?(flush=
       add_opt_rrset o q t `Additional) !addqueue;
     let _ =
       if (dnssec) then
-      let rr = Packet.({ name = []; cls = RR_IN; flush = false;
+      let rr = Packet.({ name = Name.empty; cls = RR_IN; flush = false;
                          ttl = 0x00008000l;
                          rdata = EDNS0(1500, 0, true, [])})
       in

--- a/lib/zone.ml
+++ b/lib/zone.ml
@@ -29,7 +29,7 @@ let load ?(db=new_db ()) origin buf =
     state.paren <- 0;
     state.filename <- "<string>";
     state.lineno <- 1;
-    state.origin <- List.map String.lowercase origin;
+    state.origin <- Name.of_string_list origin;
     state.ttl <- Int32.of_int 3600;
     state.owner <- state.origin;
     Zone_parser.zfile Zone_lexer.token lexbuf;

--- a/lib/zone_parser.mly
+++ b/lib/zone_parser.mly
@@ -362,19 +362,19 @@ hexword: charstring
    assume the owner field was omitted */
 owner:
    /* nothing */ { state.owner }
- | domain { state.owner <- $1 ; $1 }
+ | domain { state.owner <- $1 ; state.owner }
 
 domain:
-   DOT { [] }
+   DOT { Name.empty }
  | AT { state.origin }
- | label_except_at { (Bytes.lowercase $1) :: state.origin }
- | label DOT { [ (Bytes.lowercase $1) ] }
- | label DOT domain_labels { ((Bytes.lowercase $1) :: $3) @ state.origin }
- | label DOT domain_labels DOT { (Bytes.lowercase $1) :: $3 }
+ | label_except_at { Name.cons $1 state.origin }
+ | label DOT { Name.of_string_list ([$1]) }
+ | label DOT domain_labels { Name.cons $1 (Name.append (Name.of_string_list $3) state.origin) }
+ | label DOT domain_labels DOT { Name.of_string_list ($1 :: $3) }
 
 domain_labels:
-   label { [(Bytes.lowercase $1)] }
- | domain_labels DOT label { $1 @ [(Bytes.lowercase $3)] }
+   label { [$1] }
+ | domain_labels DOT label { $1 @ [$3] }
 
 /* It's acceptable to re-use numbers and keywords as character-strings.
    This is pretty ugly: we need special cases to distinguish a domain

--- a/lib_test/unix/time_server.ml
+++ b/lib_test/unix/time_server.ml
@@ -19,7 +19,7 @@ open Printf
 
 let time_rsrc_record () =
   Dns.Packet.(
-    let name = ["time"; "com"] in
+    let name = Dns.Name.of_string_list ["time"; "com"] in
     let cls = RR_IN in
     let flush = false in
     let ttl = 100l in

--- a/lwt/dns_server.ml
+++ b/lwt/dns_server.ml
@@ -20,6 +20,7 @@ open Printf
 
 module DR = Dns.RR
 module DP = Dns.Packet
+module DN = Dns.Name
 
 type ip_endpoint = Ipaddr.t * int
 
@@ -59,7 +60,6 @@ let process_of_zonebufs zonebufs =
     (Dns.Loader.new_db ()) zonebufs in
   let dnstrie = db.Dns.Loader.trie in
   let get_answer qname qtype id =
-    let qname = List.map String.lowercase qname in
     Dns.Query.answer ~dnssec:true qname qtype dnstrie
   in
   fun ~src ~dst d ->


### PR DESCRIPTION
This is my attempt to no longer expose that domain_name is implemented as a string list in the Name module, please review
Discussion about making domain_name abstract: https://github.com/mirage/ocaml-dns/issues/51