### PR TITLE
Query.create: do not set AA on queries

### DIFF
--- a/lib/query.ml
+++ b/lib/query.ml
@@ -73,7 +73,7 @@ let create ?(dnssec=false) ~id q_class q_type q_name =
   let open Packet in
   let detail = {
     qr=Query; opcode=Standard;
-    aa=true; tc=false; rd=true; ra=false; rcode=NoError;
+    aa=false; tc=false; rd=true; ra=false; rcode=NoError;
   } in
   let additionals =
     if dnssec then


### PR DESCRIPTION
Some DNS servers (e.g. the one in the Technicolor TG582n) will check this bit is unset and ignore packets if it is set.

This issue has been present since this function was written in 2012.