### PR TITLE
stub implement pseudoheader, now required by mirage-types

### DIFF
--- a/lib_test/ounit/test_mdns_resolver_mirage.ml
+++ b/lib_test/ounit/test_mdns_resolver_mirage.ml
@@ -79,6 +79,9 @@ module StubIpv4 (*: V1_LWT.IPV4 with type ethif = unit*) = struct
   let checksum buf bufl =
     0
 
+  let pseudoheader t ~dst ~proto len =
+    Cstruct.create 0
+
   let get_source t ~dst:_ =
     t.ip
 


### PR DESCRIPTION
@yomimono this makes the tests compile (for some reason the Dns_resolver_unix::resolution-error test fails on my FreeBSD)