### PR TITLE
compatibility with upstream UDP API changes (result types)

### DIFF
--- a/mirage/dns_resolver_mirage.ml
+++ b/mirage/dns_resolver_mirage.ml
@@ -111,7 +111,10 @@ module Make(Time:V1_LWT.TIME)(S:V1_LWT.STACKV4) = struct
       S.listen_udpv4 s ~port:src_port callback;
       let rec txfn buf =
         Cstruct.of_bigarray buf |>
-        S.UDPV4.write ~src_port ~dst ~dst_port udp in
+        S.UDPV4.write ~src_port ~dst ~dst_port udp >>= function
+        | Error (`Msg s) -> fail (Failure ("Attempting to communicate with remote resolver: " ^ s))
+        | Ok () -> Lwt.return_unit
+      in
       let rec rxfn f =
         Lwt_mvar.take mvar
         >>= fun buf ->

--- a/mirage/dns_server_mirage.ml
+++ b/mirage/dns_server_mirage.ml
@@ -66,7 +66,8 @@ module Make(K:V1_LWT.KV_RO)(S:V1_LWT.STACKV4) = struct
       | None -> return ()
       | Some rba ->
         let rbuf = Cstruct.of_bigarray rba in
-        S.UDPV4.write ~src_port:port ~dst:src ~dst_port:src_port udp rbuf
+        (* Do not attempt to retry if serving failed *)
+        S.UDPV4.write ~src_port:port ~dst:src ~dst_port:src_port udp rbuf >|= fun _ -> ()
     in
     S.listen_udpv4 t.s port listener;
     S.listen t.s

--- a/mirage/mdns_resolver_mirage.ml
+++ b/mirage/mdns_resolver_mirage.ml
@@ -100,7 +100,10 @@ module Make(Time:V1_LWT.TIME)(S:V1_LWT.STACKV4) = struct
       S.listen_udpv4 s ~port:src_port callback;
       let rec txfn buf =
         Cstruct.of_bigarray buf |>
-        S.UDPV4.write ~src_port ~dst ~dst_port udp in
+        S.UDPV4.write ~src_port ~dst ~dst_port udp >>= function
+        | Error (`Msg s) -> fail (Failure ("Attempting to communicate with remote resolver: " ^ s))
+        | Ok () -> Lwt.return_unit
+      in
       let rec rxfn f =
         Lwt_mvar.take mvar
         >>= fun buf ->


### PR DESCRIPTION
This PR causes `dns` to build proposed upstream Mirage 3 API changes, but will break backward compatibility with the current released mirage package set. See mirage/mirage#690 for details on the upstream changes to the API.