### PR TITLE
Prepare to release v0.19.1 again

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,9 @@
-## 0.19.1 (2017-02-09)
+## 0.19.1 (2017-02-15)
 
 * Use topkg instead of oasis (#126)
 * Do not reverse the order of resource records in the parser (#109)
 * Restrict to OCaml 4.03.0+.
+* Fix bug parsing pointers to pointers to DNS name labels (#129)
 
 ## 0.19.0 (2017-01-20)
 


### PR DESCRIPTION
Previously a v0.19.1 release was started but never tagged. Let's
try again but including the DNS parsing pointer to pointer fix.

Signed-off-by: David Scott <dave@recoil.org>