### PR TITLE
zone_parser: explictly depend on uri.services

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 0.20.2 (2017-06-01)
+
+* Depend explicitly on `Ipaddr_unix` and `Uri_services` modules.
+
 ## 0.20.1 (2017-05-16)
 
 * Port to lwt >= 3.0 (#136, @djs55)

--- a/_tags
+++ b/_tags
@@ -8,6 +8,7 @@ true : package(re re.str ipaddr uri base64 hashcons cstruct result)
 
 "lwt": include
 <lwt/*.{ml,mli}>: package(lwt mirage-profile)
+<lwt/dns_*_unix.*>: package(ipaddr.unix)
 <lwt/dig_unix.*>: package(cmdliner lwt.unix uri.services ipaddr.unix lwt)
 <lib/zone_parser.*>: package(uri.services)
 <mirage/*.{ml,mli}>: package(lwt duration mirage-time-lwt)

--- a/_tags
+++ b/_tags
@@ -9,6 +9,7 @@ true : package(re re.str ipaddr uri base64 hashcons cstruct result)
 "lwt": include
 <lwt/*.{ml,mli}>: package(lwt mirage-profile)
 <lwt/dig_unix.*>: package(cmdliner lwt.unix uri.services ipaddr.unix lwt)
+<lib/zone_parser.*>: package(uri.services)
 <mirage/*.{ml,mli}>: package(lwt duration mirage-time-lwt)
 <mirage/*.{ml,mli}>: package(mirage-stack-lwt mirage-kv-lwt)
 

--- a/opam
+++ b/opam
@@ -39,6 +39,7 @@ depends: [
   "ppx_tools"        {build}
   "base-bytes"
   "cstruct"          {>= "2.0.0"}
+  "ppx_cstruct"      {build}
   "re"
   "ipaddr"           {>= "2.6.0"}
   "uri"              {>= "1.7.0"}


### PR DESCRIPTION
This seems to have been pulled in implicitly before, but breaks
when compiled with jbuilder