### PR TITLE
Move command line parser from dns-lwt-unix to an executable.

### DIFF
--- a/lwt-unix/jbuild
+++ b/lwt-unix/jbuild
@@ -1,6 +1,12 @@
 (library
  ((name        dns_lwt_unix) 
   (public_name dns-lwt-unix)
-  (libraries   (dns-lwt mirage-profile cmdliner ipaddr.unix lwt.unix))
+  (modules     (:standard \ Dig_unix))
+  (libraries   (dns-lwt mirage-profile ipaddr.unix lwt.unix))
   (wrapped false)
 ))
+
+(executable
+ ((name    dig_unix)
+  (modules (Dig_unix))
+  (libraries (cmdliner dns_lwt_unix))))


### PR DESCRIPTION
This fixes #151.