### PR TITLE
Pass package names to jbuilder subst.

### DIFF
--- a/dns-async.opam
+++ b/dns-async.opam
@@ -10,7 +10,7 @@ authors: [ "Anil Madhavapeddy" "Tim Deegan" "Richard Mortier" "Haris Rotsos"
 tags: [ "org:mirage" "org:xapi-project" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-n" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/dns-lwt-unix.opam
+++ b/dns-lwt-unix.opam
@@ -11,7 +11,7 @@ authors: [
   "David Sheets" "Thomas Gazagnaire" "Luke Dunstan" "David Scott" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-n" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/dns-lwt.opam
+++ b/dns-lwt.opam
@@ -12,7 +12,7 @@ authors: [
 license: "ISC"
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-n" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/dns.opam
+++ b/dns.opam
@@ -13,7 +13,7 @@ license: "ISC"
 tags: [ "org:mirage" "org:xapi-project" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-n" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 

--- a/mirage-dns.opam
+++ b/mirage-dns.opam
@@ -8,7 +8,7 @@ authors: [ "Anil Madhavapeddy" "Tim Deegan" "Richard Mortier" "Haris Rotsos"
   "David Sheets" "Thomas Gazagnaire" "Luke Dunstan" ]
 
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-n" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 


### PR DESCRIPTION
Pinning to --dev-repo currently fails, since jbuilder (1.0+beta20) cannot determine the package name.  An example error from opam 2.0.0~rc:
```
#=== ERROR while compiling dns-lwt-unix.1.0.1 =================================#
# context      2.0.0~rc | linux/x86_64 | base-bigarray.base base-threads.base base-unix.base ocaml-base-compiler.4.06.1 | pinned(git+https://github.com/mirage/ocaml-dns.git#c188f696)
# path         ~/.opam/4.06.1/.opam-switch/build/dns-lwt-unix.1.0.1
# command      ~/.opam/4.06.1/bin/jbuilder subst
# exit-code    1
# env-file     ~/.opam/log/dns-lwt-unix-16184-d0f245.env
# output-file  ~/.opam/log/dns-lwt-unix-16184-d0f245.out
### output ###
# Error: cannot determine name automatically.
# You must pass a [--name] command line argument.
```