### PR TITLE
Correction on parsing function : pattern matching is not correct, total length is not checked

### DIFF
--- a/lib/name.ml
+++ b/lib/name.ml
@@ -67,7 +67,7 @@ let parse_label base buf =
     | 0 ->
         Z base, 1
 
-    | v when ((v land 0b0_11000000) != 0) ->
+    | v when ((v land 0b0_11000000) == 0b0_11000000) ->
         let ptr = ((v land 0b0_00111111) lsl 8) + Cstruct.get_uint8 buf 1 in
         P (ptr, base), 2
 

--- a/lib/name.ml
+++ b/lib/name.ml
@@ -67,7 +67,7 @@ let parse_label base buf =
     | 0 ->
         Z base, 1
 
-    | v when ((v land 0b0_11000000) == 0b0_11000000) ->
+    | v when ((v land 0b0_11000000) = 0b0_11000000) ->
         let ptr = ((v land 0b0_00111111) lsl 8) + Cstruct.get_uint8 buf 1 in
         P (ptr, base), 2
 

--- a/lib/packet.mli
+++ b/lib/packet.mli
@@ -321,7 +321,7 @@ val parse_question :
 type qr = Query | Response
 
 (** A DNS opcode, with the usual conversion functions. *)
-type opcode = Standard | Inverse | Status | Reserved | Notify | Update
+type opcode = Standard | Inverse | Status | Notify | Update | Reserved of int
 val opcode_to_string : opcode -> string
 
 (** A DNS response code, with the usual conversion functions. *)

--- a/lib/probe.ml
+++ b/lib/probe.ml
@@ -211,10 +211,10 @@ let rename_unique state old_name =
   let increment_name name =
     match Name.to_string_list name with
     | head :: tail ->
-      let re = Re_str.regexp "\\(.*\\)\\([0-9]+\\)" in
-      let new_head = if Re_str.string_match re head 0 then begin
-          let num = int_of_string (Re_str.matched_group 2 head) in
-          (Re_str.matched_group 1 head) ^ (string_of_int (num + 1))
+      let re = Re.Str.regexp "\\(.*\\)\\([0-9]+\\)" in
+      let new_head = if Re.Str.string_match re head 0 then begin
+          let num = int_of_string (Re.Str.matched_group 2 head) in
+          (Re.Str.matched_group 1 head) ^ (string_of_int (num + 1))
         end else
           head ^ "2"
       in

--- a/lib_test/ounit/test_name.ml
+++ b/lib_test/ounit/test_name.ml
@@ -4,7 +4,7 @@ open OUnit2
 let cstruct_of ints =
   let buf = Buffer.create (List.length ints) in
   ints |> List.iter (fun i ->
-    Buffer.add_char buf (Char.chr i));
+      Buffer.add_char buf (Char.chr i));
   Cstruct.of_string (Buffer.contents buf)
 
 open Dns
@@ -14,110 +14,154 @@ let tests =
   "Name" >:::
   [
     "parse-root-domain-name" >:: (fun test_ctxt ->
-      let buf = cstruct_of [0x00] in
-      let names = Hashtbl.create 32 in
-      let name, (base,buf) = parse names 0 buf in
-      assert_equal "" (Name.to_string name);
-    );
+        let buf = cstruct_of [0x00] in
+        let names = Hashtbl.create 32 in
+        let name, (base,buf) = parse names 0 buf in
+        assert_equal "" (Name.to_string name);
+      );
 
     "parse-label-single" >:: (fun test_ctxt ->
-      let buf = cstruct_of [
-        0x03; 0x63; 0x6f; 0x6d;
-        0x00
-      ] in
-      let names = Hashtbl.create 32 in
-      let name, (base,buf) = parse names 0 buf in
-      assert_equal "com" (Name.to_string name);
-    );
+        let buf = cstruct_of [
+            0x03; 0x63; 0x6f; 0x6d;
+            0x00
+          ] in
+        let names = Hashtbl.create 32 in
+        let name, (base,buf) = parse names 0 buf in
+        assert_equal "com" (Name.to_string name);
+      );
 
     "parse-label-seq" >:: (fun test_ctxt ->
-      let buf = cstruct_of [
-        0x03; 0x66; 0x6f; 0x6f;
-        0x03; 0x63; 0x6f; 0x6d;
-        0x00
-      ] in
-      let names = Hashtbl.create 32 in
-      let name, (base,buf) = parse names 0 buf in
-      assert_equal "foo.com" (Name.to_string name);
-    );
+        let buf = cstruct_of [
+            0x03; 0x66; 0x6f; 0x6f;
+            0x03; 0x63; 0x6f; 0x6d;
+            0x00
+          ] in
+        let names = Hashtbl.create 32 in
+        let name, (base,buf) = parse names 0 buf in
+        assert_equal "foo.com" (Name.to_string name);
+      );
 
     "parse-pointer-to-root-domain" >:: (fun test_ctxt ->
-      let buf = cstruct_of [
-        0xff; (* padding *)
-        0x00;
-        0xc0; 0x01
-      ] in
-      let names = Hashtbl.create 32 in
-      let buf = Cstruct.shift buf 1 in
-      let name, (base,buf) = parse names 1 buf in
-      let name, (base,buf) = parse names 2 buf in
-      assert_equal "" (Name.to_string name);
-    );
+        let buf = cstruct_of [
+            0xff; (* padding *)
+            0x00;
+            0xc0; 0x01
+          ] in
+        let names = Hashtbl.create 32 in
+        let buf = Cstruct.shift buf 1 in
+        let name, (base,buf) = parse names 1 buf in
+        let name, (base,buf) = parse names 2 buf in
+        assert_equal "" (Name.to_string name);
+      );
 
     "parse-pointer-to-label" >:: (fun test_ctxt ->
-      let buf = cstruct_of [
-        0x03; 0x63; 0x6f; 0x6d;
-        0x00;
-        0xc0; 0x00
-      ] in
-      let names = Hashtbl.create 32 in
-      let name, (base,buf) = parse names 0 buf in
-      let name, (base,buf) = parse names base buf in
-      assert_equal "com" (Name.to_string name);
-    );
+        let buf = cstruct_of [
+            0x03; 0x63; 0x6f; 0x6d;
+            0x00;
+            0xc0; 0x00
+          ] in
+        let names = Hashtbl.create 32 in
+        let name, (base,buf) = parse names 0 buf in
+        let name, (base,buf) = parse names base buf in
+        assert_equal "com" (Name.to_string name);
+      );
 
     "parse-pointer-to-pointer-to-label" >:: (fun test_ctxt ->
-      let buf = cstruct_of [
-        0x03; 0x63; 0x6f; 0x6d;
-        0x00;
-        0xc0; 0x00;
-        0xc0; 0x05
-      ] in
-      let names = Hashtbl.create 32 in
-      let name, (base,buf) = parse names 0 buf in
-      let name, (base,buf) = parse names base buf in
-      let name, (base,buf) = parse names base buf in
-      assert_equal "com" (Name.to_string name);
-    );
+        let buf = cstruct_of [
+            0x03; 0x63; 0x6f; 0x6d;
+            0x00;
+            0xc0; 0x00;
+            0xc0; 0x05
+          ] in
+        let names = Hashtbl.create 32 in
+        let name, (base,buf) = parse names 0 buf in
+        let name, (base,buf) = parse names base buf in
+        let name, (base,buf) = parse names base buf in
+        assert_equal "com" (Name.to_string name);
+      );
 
     "parse-label-then-label-with-pointer-to-label" >:: (fun test_ctxt ->
-      let buf = cstruct_of [
-        0x03; 0x63; 0x6f; 0x6d;
-        0x00;
-        0x03; 0x66; 0x6f; 0x6f;
-        0xc0; 0x00
-      ] in
-      let names = Hashtbl.create 32 in
-      let name, (base,buf) = parse names 0 buf in
-      let name, (base,buf) = parse names base buf in
-      assert_equal "foo.com" (Name.to_string name);
-    );
+        let buf = cstruct_of [
+            0x03; 0x63; 0x6f; 0x6d;
+            0x00;
+            0x03; 0x66; 0x6f; 0x6f;
+            0xc0; 0x00
+          ] in
+        let names = Hashtbl.create 32 in
+        let name, (base,buf) = parse names 0 buf in
+        let name, (base,buf) = parse names base buf in
+        assert_equal "foo.com" (Name.to_string name);
+      );
 
     "parse-pointer-to-self" >:: (fun test_ctxt ->
-      let buf = cstruct_of [ 0xc0; 0x00 ] in
-      let names = Hashtbl.create 32 in
-      assert_raises
-        (Failure "Name.parse_pointer: Cannot dereference pointer to (0) at position (0)")
-        (fun () -> parse names 0 buf)
-    );
+        let buf = cstruct_of [ 0xc0; 0x00 ] in
+        let names = Hashtbl.create 32 in
+        assert_raises
+          (Failure "Name.parse_pointer: Cannot dereference pointer to (0) at position (0)")
+          (fun () -> parse names 0 buf)
+      );
 
     "parse-pointer-to-invalid-address" >:: (fun test_ctxt ->
-      let buf = cstruct_of [ 0xc0; 0x0e ] in
-      let names = Hashtbl.create 32 in
-      assert_raises
-        (Failure "Name.parse_pointer: Cannot dereference pointer to (14) at position (0)")
-        (fun () -> parse names 0 buf)
-    );
+        let buf = cstruct_of [ 0xc0; 0x0e ] in
+        let names = Hashtbl.create 32 in
+        assert_raises
+          (Failure "Name.parse_pointer: Cannot dereference pointer to (14) at position (0)")
+          (fun () -> parse names 0 buf)
+      );
 
     "parse-pointer-cycle" >:: (fun test_ctxt ->
-      let buf = cstruct_of [
-        0xc0; 0x02;
-        0xc0; 0x00
-      ] in
-      let names = Hashtbl.create 32 in
-      assert_raises
-        (Failure "Name.parse_pointer: Cannot dereference pointer to (2) at position (0)")
-        (fun () -> parse names 0 buf)
-    );
+        let buf = cstruct_of [
+            0xc0; 0x02;
+            0xc0; 0x00
+          ] in
+        let names = Hashtbl.create 32 in
+        assert_raises
+          (Failure "Name.parse_pointer: Cannot dereference pointer to (2) at position (0)")
+          (fun () -> parse names 0 buf)
+      );
 
+    "parse-corrupted-label" >:: (fun test_ctxt ->
+        let buf = cstruct_of [0x40] in
+        let names = Hashtbl.create 32 in
+        assert_raises
+          (Failure "Name.parse_label: invalid length 64")
+          (fun () -> parse names 0 buf)
+      );
+
+        "parse-name-too-long" >:: (fun test_ctxt ->
+        let buf = cstruct_of [
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x09; 0x61; 0x62; 0x63; 0x64; 0x65; 0x66; 0x67; 0x68; 0x69;
+            0x04; 0x61; 0x62; 0x63; 0x64; 0x00;   
+          ]
+        in
+        let names = Hashtbl.create 32 in
+        assert_raises
+          (Failure "Name.parse: invalid length 256")
+          (fun () -> parse names 0 buf)
+      );
+    
   ]


### PR DESCRIPTION
Domain name labels can be either be empty (root), text labels or pointers. The first two bits help to distinguish text labels from pointers : text labels start with two 0 bits (e.g. 0b0_00000001), whereas pointers start with two 1 bits (e.g. 0b0_11000001). That means, any label starting with 10 or 01 is invalid.

However, the parsing function in name.ml did it wrong when checking for pointers. It only checks if one of the two first bits are 1 to assume it's a pointer :
`let v = 0b0_10000001 in (v land 0b0_11000000) != 0` returns `true` even though v isn't a pointer.

A solution would be to replace 
`(v land 0b0_11000000) != 0` 
with 
`(v land 0b0_11000000) == 0b0_11000000`.

Another solution could be `v >= 0b0_11000000`.