### PR TITLE
[1.1 branch] Domain name 0.3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
    - PINS="mirage-dns:. dns-async:. dns-lwt:. dns-lwt-unix:."
    - PACKAGE="dns"
    - DEPOPTS="dns-async dns-lwt dns-lwt-unix"
+   - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
  matrix:
    - DISTRO=debian-stable OCAML_VERSION=4.03
    - DISTRO=debian-testing OCAML_VERSION=4.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ env:
    - DEPOPTS="dns-async dns-lwt dns-lwt-unix"
    - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
  matrix:
-   - DISTRO=debian-stable OCAML_VERSION=4.03
-   - DISTRO=debian-testing OCAML_VERSION=4.04
+   - DISTRO=debian-stable OCAML_VERSION=4.04
    - DISTRO=ubuntu-lts OCAML_VERSION=4.05 DEPOPTS="mirage-dns dns-async dns-lwt dns-lwt-unix"
    - DISTRO=alpine OCAML_VERSION=4.06 DEPOPTS="mirage-dns dns-async dns-lwt dns-lwt-unix"
    - DISTRO=fedora OCAML_VERSION=4.07 DEPOPTS="mirage-dns dns-async dns-lwt dns-lwt-unix"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ### v1.1.3 (2019-07-16)
-* Support domain-name.0.3.0 interface (@avsm)
+
+* Support domain-name.0.3.0 interface, which bumps the minimum
+  OCaml version supported to 4.04 due to that dependency (@avsm)
 * Fix tests with recent OCaml (use mmap/bigarray-compat) (@avsm)
 
 ### v1.1.2 (2019-02-28)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### v1.1.3 (2019-07-16)
 * Support domain-name.0.3.0 interface (@avsm)
+* Fix tests with recent OCaml (use mmap/bigarray-compat) (@avsm)
 
 ### v1.1.2 (2019-02-28)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### v1.1.3 (2019-07-16)
+* Support domain-name.0.3.0 interface (@avsm)
+
 ### v1.1.2 (2019-02-28)
 
 * Mirage: adapt to mirage-kv 2.0.0 interface (#156 by @samoht)

--- a/async/async_dns_resolver_unix.mli
+++ b/async/async_dns_resolver_unix.mli
@@ -17,7 +17,6 @@
 
 (** Async DNS resolution interface on Unix *)
 
-open !Core
 open !Async
 
 val gethostbyname :

--- a/dns.opam
+++ b/dns.opam
@@ -31,12 +31,13 @@ doc: "https://mirage.github.io/ocaml-dns/"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build}
+  "dune"
   "cstruct" {>= "3.0.2"}
   "ppx_cstruct"
   "re" {>="1.7.2"}
   "ipaddr" {>= "2.6.0"}
   "uri" {>= "1.7.0"}
+  "domain-name" {>="0.3.0"}
   "base64" {>= "3.0.0"}
   "hashcons"
   "result"

--- a/dns.opam
+++ b/dns.opam
@@ -41,6 +41,8 @@ depends: [
   "base64" {>= "3.0.0"}
   "hashcons"
   "result"
+  "mmap" {with-test}
+  "bigarray-compat" {with-test}
   "pcap-format" {with-test}
   "ounit" {with-test}
 ]

--- a/lib/name.ml
+++ b/lib/name.ml
@@ -54,7 +54,7 @@ let of_string (s:string) : t =
   Re.Str.split (Re.Str.regexp "\\.") (String.lowercase_ascii s)
 let string_to_domain_name = of_string
 
-let of_ipaddr ip = of_string_list (Ipaddr.to_domain_name ip)
+let of_ipaddr ip = of_string_list (Ipaddr.to_domain_name ip |> Domain_name.to_strings)
 
 type label =
   | L of string * int (* string *)

--- a/lib_test/ounit/dune
+++ b/lib_test/ounit/dune
@@ -1,6 +1,6 @@
 (test
   (name       test)
-  (libraries  dns oUnit pcap-format)
+  (libraries  dns oUnit pcap-format bigarray-compat mmap)
   (package    dns)
   (deps       (glob_files *.pcap) (glob_files *.zone))
   (preprocess (pps ppx_cstruct)))

--- a/lib_test/ounit/test_packet.ml
+++ b/lib_test/ounit/test_packet.ml
@@ -38,7 +38,7 @@ type udpv4 = {
 
 let load_pcap path =
   let fd = Unix.(openfile path [O_RDONLY] 0) in
-  let buf = Bigarray.(Array1.map_file fd Bigarray.char c_layout false (-1)) in
+  let buf = Bigarray.(array1_of_genarray (Mmap.V1.map_file fd Bigarray.char c_layout false [|-1|])) in
   let buf = Cstruct.of_bigarray buf in
   let header, body = Cstruct.split buf Pcap.sizeof_pcap_header in
   match Pcap.detect header with


### PR DESCRIPTION
This is just the minimal changes to cut a point release of 1.1.3 so that we remove an upper bound on domain-name (and unblock ipaddr.4.0.0)