### PR TITLE
fixes #110

### DIFF
--- a/unix/client/dns_client_unix.mli
+++ b/unix/client/dns_client_unix.mli
@@ -6,7 +6,19 @@
 (** A flow module based on blocking I/O on top of the Unix socket API. *)
 module Uflow : Dns_client_flow.S
   with type flow = Unix.file_descr
-   and type io_addr = Unix.inet_addr * int
+
+   and type io_addr =
+   (** The first element in the [io_addr] tuple is a list of socket options
+       to be applied to socket connection to the server.
+       They will be applied before [Unix.connect].
+       The remaining elements designate the IP and port number of the server.*)
+         [ `Bool of Unix.socket_bool_option
+         | `Int of Unix.socket_int_option
+         | `Intopt of Unix.socket_optint_option
+         | `Float of Unix.socket_float_option
+         ] list
+         * Unix.inet_addr * int
+
    and type stack = unit
    and type (+'a,+'b) io = ('a,'b) result
 


### PR DESCRIPTION
1) FWIW this is one possible way to solve #110 
    - EDIT: Well, besides `Unix.setsockopt` not allowing you to bind a socket to an interface. You can bind it to an address using `Unix.bind`, but that doesn't guarantee anything about the interface unless you're using raw sockets, which `Unix.sockaddr` does not expose.
    - EDIT 2: Perhaps you can `Unix.bind` to a specific device with an IPv6 address with zone id `[::%eth0]`, this is maybe the most portable you can get. Not sure if the stdlib supports that.


2) Another approach could be to instead take an already connected socket (which the application can then setup however it wants) - (EDIT: With this kind of interface you are free to pursue platform-specific ways to bind sockets to interface, e.g. `SO_BINDTODEVICE` on Linux):
```ocaml
  type io_addr =
    | `Fd of Unix.file_descr
    | `Address of Unix.inet_addr * int
```

3) That however becomes problematic if we ever want to do automatic reconnections. In that case one could conceivably have:
```ocaml
  type io_addr =
    | `Connect_function of (unit -> (Unix.file_descr, [> `Msg of string]) io)
    | `Address of Unix.inet_addr * int
```

I don't have a use-case for socket options, so I don't have an opinion.
3) seems to me like the most portable interface to allow the same for other backends since that could work for `Lwt` / `Mirage` too without too many modifications.

ping @jerome-arzel and @hannesm 