### PR TITLE
provide dynamic update of HMAC / TSIG keys

### DIFF
--- a/app/ocertify.ml
+++ b/app/ocertify.ml
@@ -40,7 +40,7 @@ let nsupdate_csr sock host keyname zone dnskey csr =
     | Ok () -> Ok ()
     | Error e -> Error (`Msg (Fmt.strf "nsupdate reply error %a" Dns_certify.pp_u_err e))
 
-let jump _ server_ip port (keyname, zone, dnskey) hostname csr key seed bits cert force =
+let jump _ server_ip port hostname dns_key_opt csr key seed bits cert force =
   Nocrypto_entropy_unix.initialize ();
   let fn suffix = function
     | None -> Fpath.(v (Domain_name.to_string hostname) + suffix)
@@ -101,25 +101,28 @@ let jump _ server_ip port (keyname, zone, dnskey) hostname csr key seed bits cer
        Error (`Msg (Fmt.strf "error %a while parsing TLSA reply" Dns_certify.pp_q_err e)))
   >>= fun send_update ->
   if send_update then
-    nsupdate_csr sock hostname keyname zone dnskey req >>= fun () ->
-    let rec request retries =
-      if retries = 0 then
-        Error (`Msg "failed to request certificate")
-      else
-        match query_certificate sock public_key hostname with
-        | Error `No_tlsa ->
-          Logs.warn (fun m -> m "still no tlsa, sleeping two more seconds");
-          Unix.sleep 2;
-          request (pred retries)
-        | Error (`Msg msg) ->
-          Logs.err (fun m -> m "error %s" msg);
-          Error (`Msg msg)
-        | Error ((`Decode _ | `Bad_reply _ | `Unexpected_reply _) as e) ->
-          Logs.err (fun m -> m "error %a while handling TLSA reply (retrying anyways)" Dns_certify.pp_q_err e);
-          request (pred retries)
-        | Ok x -> write_certificate x
-    in
-    request 10
+    match dns_key_opt with
+    | None -> Error (`Msg "no dnskey provided, but required for uploading CSR")
+    | Some (keyname, zone, dnskey) ->
+      nsupdate_csr sock hostname keyname zone dnskey req >>= fun () ->
+      let rec request retries =
+        if retries = 0 then
+          Error (`Msg "failed to request certificate")
+        else
+          match query_certificate sock public_key hostname with
+          | Error `No_tlsa ->
+            Logs.warn (fun m -> m "still no tlsa, sleeping two more seconds");
+            Unix.sleep 2;
+            request (pred retries)
+          | Error (`Msg msg) ->
+            Logs.err (fun m -> m "error %s" msg);
+            Error (`Msg msg)
+          | Error ((`Decode _ | `Bad_reply _ | `Unexpected_reply _) as e) ->
+            Logs.err (fun m -> m "error %a while handling TLSA reply (retrying anyways)" Dns_certify.pp_q_err e);
+            request (pred retries)
+          | Ok x -> write_certificate x
+      in
+      request 10
   else
     Ok ()
 
@@ -135,11 +138,11 @@ let port =
 
 let dns_key =
   let doc = "nsupdate key (name:alg:b64key, where name is YYY._update.zone)" in
-  Arg.(required & pos 1 (some Dns_cli.namekey_c) None & info [] ~doc ~docv:"KEY")
+  Arg.(value & opt (some Dns_cli.namekey_c) None & info [ "dns-key" ] ~doc ~docv:"KEY")
 
 let hostname =
   let doc = "Hostname (FQDN) to issue a certificate for" in
-  Arg.(required & pos 2 (some Dns_cli.name_c) None & info [] ~doc ~docv:"HOSTNAME")
+  Arg.(required & pos 1 (some Dns_cli.name_c) None & info [] ~doc ~docv:"HOSTNAME")
 
 let csr =
   let doc = "certificate signing request filename (defaults to hostname.req)" in
@@ -168,7 +171,7 @@ let force =
 let ocertify =
   let doc = "ocertify requests a signed certificate" in
   let man = [ `S "BUGS"; `P "Submit bugs to me";] in
-  Term.(term_result (const jump $ Dns_cli.setup_log $ dns_server $ port $ dns_key $ hostname $ csr $ key $ seed $ bits $ cert $ force)),
+  Term.(term_result (const jump $ Dns_cli.setup_log $ dns_server $ port $ hostname $ dns_key $ csr $ key $ seed $ bits $ cert $ force)),
   Term.info "ocertify" ~version:"%%VERSION_NUM%%" ~doc ~man
 
 let () = match Term.eval ocertify with `Ok () -> exit 0 | _ -> exit 1

--- a/mirage/server/dns_mirage_server.ml
+++ b/mirage/server/dns_mirage_server.ml
@@ -62,10 +62,11 @@ module Make (P : Mirage_clock_lwt.PCLOCK) (M : Mirage_clock_lwt.MCLOCK) (TIME : 
       | None -> Lwt.return_unit
       | Some n -> on_notify n t >>= function
         | None -> Lwt.return_unit
-        | Some trie ->
-          let state', outs = Dns_server.Primary.with_data t now ts trie in
-          state := state';
-          Lwt_list.iter_p (send_notify recv_task) outs
+        | Some (trie, keys) ->
+          let state', outs = Dns_server.Primary.with_keys t now ts keys in
+          let state'', outs' = Dns_server.Primary.with_data state' now ts trie in
+          state := state'';
+          Lwt_list.iter_p (send_notify recv_task) (outs @ outs')
     in
 
     let rec recv_task ip port flow () =

--- a/mirage/server/dns_mirage_server.mli
+++ b/mirage/server/dns_mirage_server.mli
@@ -3,7 +3,9 @@
 module Make (P : Mirage_clock_lwt.PCLOCK) (M : Mirage_clock_lwt.MCLOCK) (T : Mirage_time_lwt.S) (S : Mirage_stack_lwt.V4) : sig
 
   val primary : ?on_update:(old:Dns_trie.t -> Dns_server.Primary.s -> unit Lwt.t) ->
-    ?on_notify:([ `Notify of Dns.Soa.t option | `Signed_notify of Dns.Soa.t option ] -> Dns_server.Primary.s -> Dns_trie.t option Lwt.t) ->
+    ?on_notify:([ `Notify of Dns.Soa.t option | `Signed_notify of Dns.Soa.t option ] ->
+                Dns_server.Primary.s ->
+                (Dns_trie.t * ([ `raw ] Domain_name.t * Dns.Dnskey.t) list) option Lwt.t) ->
     ?timer:int -> ?port:int -> S.t -> Dns_server.Primary.s -> unit
   (** [primary ~on_update ~timer ~port stack primary] starts a primary server on [port]
      (default 53, both TCP and UDP) with the given [primary] configuration. [timer] is the

--- a/server/dns_server.ml
+++ b/server/dns_server.ml
@@ -743,6 +743,69 @@ module Primary = struct
     let m' = update_trie_cache m t.data in
     ({ t with data }, m', l, n''), out @ out'
 
+  let with_keys (t, m, l, n) now ts keys =
+    let auth = Authentication.of_keys keys in
+    let old, au = t.auth in
+    (* need to diff the old and new keys *)
+    let added =
+      Dns_trie.fold Rr_map.Dnskey auth (fun name _ acc ->
+          match Dns_trie.lookup name Rr_map.Dnskey old with
+          | Ok _ -> acc
+          | Error _ -> Domain_name.Set.add name acc) Domain_name.Set.empty
+    and removed =
+      Dns_trie.fold Rr_map.Dnskey old (fun name _ acc ->
+          match Dns_trie.lookup name Rr_map.Dnskey auth with
+          | Ok _ -> acc
+          | Error _ -> Domain_name.Set.add name acc) Domain_name.Set.empty
+    in
+    (* drop all removed keys from connections & notifications *)
+    let l' = Domain_name.Host_map.fold (fun name v acc ->
+        match List.filter (fun (n, _) -> not (Domain_name.Set.mem n removed)) v with
+        | [] -> acc
+        | v' -> Domain_name.Host_map.add name v' acc)
+        l Domain_name.Host_map.empty
+    and n' = IPM.fold (fun ip m acc ->
+        let m' = Domain_name.Host_map.fold (fun name v acc ->
+            match v with
+            | _, _, _, _, Some key when Domain_name.Set.mem key removed -> acc
+            | _ -> Domain_name.Host_map.add name v acc)
+            m Domain_name.Host_map.empty
+        in
+        if Domain_name.Host_map.is_empty m' then acc else IPM.add ip m' acc)
+        n IPM.empty
+    in
+    let t' = { t with auth = (auth, au) } in
+    (* for new transfer keys, send notifies out (with respective zone) *)
+    let n'', outs =
+      Domain_name.Set.fold (fun key (ns, out) ->
+          match Authentication.find_zone_ips key with
+          | Some (zone, _, Some secondary) ->
+            let notify =
+              if Domain_name.(equal zone root) then
+                Dns_trie.fold Soa t'.data (fun name soa n -> (name, soa)::n) []
+              else
+                match Dns_trie.lookup zone Rr_map.Soa t'.data with
+                | Error _ -> []
+                | Ok soa -> [zone, soa]
+            in
+            List.fold_left (fun (ns, outs) (name, soa) ->
+                match Domain_name.host name with
+                | Error (`Msg msg) ->
+                  Log.warn (fun m -> m "non-hostname notification %a: %s"
+                               Domain_name.pp name msg);
+                  ns, outs
+                | Ok host ->
+                  let ns, out =
+                    let key = Some key in
+                    Notification.notify_one ns t' now ts host soa secondary key
+                  in
+                  ns, out :: outs)
+              (ns, out) notify
+          | _ -> ns, out)
+        added (n', [])
+    in
+    (t', m, l', n''), outs
+
   let create ?(keys = []) ?(a = []) ?tsig_verify ?tsig_sign ~rng data =
     let keys = Authentication.of_keys keys in
     let t = create ?tsig_verify ?tsig_sign data (keys, a) rng in

--- a/server/dns_server.ml
+++ b/server/dns_server.ml
@@ -31,9 +31,10 @@ module Authentication = struct
     | `Transfer -> "_transfer"
 
   let is_op op name =
-    (* TODO should check that op is at the beginning? *)
-    let arr = Domain_name.to_array name in
-    Array.exists (String.equal (operation_to_string op)) arr
+    let lbl = operation_to_string op in
+    match Domain_name.(find_label name (equal_label lbl)) with
+    | None -> false
+    | Some _ -> true
 
   let find_zone_ips name =
     (* the name of a key is primaryip.secondaryip._transfer.zone

--- a/server/dns_server.mli
+++ b/server/dns_server.mli
@@ -65,6 +65,11 @@ module Primary : sig
   (** [with_data s now ts trie] replaces the current data with [trie] in [s].
       The returned notifications should be send out. *)
 
+  val with_keys : s -> Ptime.t -> int64 -> ('a Domain_name.t * Dnskey.t) list ->
+    s * (Ipaddr.V4.t * Cstruct.t) list
+  (** [with_keys s now ts keys] replaces the current keys with [keys] in [s],
+      and generates notifications. *)
+
   val create : ?keys:('a Domain_name.t * Dnskey.t) list ->
     ?a:Authentication.a list -> ?tsig_verify:Tsig_op.verify ->
     ?tsig_sign:Tsig_op.sign -> rng:(int -> Cstruct.t) -> Dns_trie.t -> s


### PR DESCRIPTION
this has been on some branch for a while, the primary server now contains a function to update the keys. Upon a key update, various janitoring is done (potentially notifications are generated (when new keys are added), other notifications are dropped (when keys are removed)).

This functionality is not exposed via `nsupdate` (which was the case in an earlier no longer existing incarnation of uDNS -- with various `_key-management` keys -- a bad idea to transmit secrets in the clear via the wire), but via API. In deployments I use this to dynamically update the keys from a zone file stored in a git remote (to which someone pushes, and the unikernel pulls after getting notified).

two other commits in this PR:
- do not _require_ a DNS key in ocertify -- there are valid uses that only download the (already existing) TLSA record
- instead of calling `Domain_name.to_array` and manually walking through the label array, use the functions of domain-name 0.3.0 (esp. `find_label`)