### PR TITLE
Dns_client_flow: require "close : flow -> (unit, 'err) io" to close a flow

### DIFF
--- a/client/dns_client_flow.mli
+++ b/client/dns_client_flow.mli
@@ -49,6 +49,9 @@ module type S = sig
   val recv : flow -> (Cstruct.t, 'err) io
   (** [recv flow] tries to read a [buffer] from the [flow] downstream.*)
 
+  val close : flow -> (unit, 'err) io
+  (** [close flow] closes the [flow], freeing up resources. *)
+
   val resolve : ('ok,'err) io -> ('ok -> ('next,'err) result) -> ('next,'err) io
   (** a.k.a. [>|=] *)
 

--- a/lwt/client/dns_client_lwt.ml
+++ b/lwt/client/dns_client_lwt.ml
@@ -24,24 +24,42 @@ module Uflow : Dns_client_flow.S
 
   let nameserver { nameserver } = nameserver
 
+  let safe_close socket =
+    Lwt.catch (fun () -> Lwt_unix.close socket) (fun _ -> Lwt.return_unit)
+
   let send socket tx =
     let open Lwt in
-    Lwt_unix.send socket (Cstruct.to_bytes tx) 0
-      (Cstruct.len tx) [] >>= fun res ->
-    if res <> Cstruct.len tx then
-      Lwt_result.fail (`Msg ("oops" ^ (string_of_int res)))
-    else
-      Lwt_result.return ()
+    Lwt.catch (fun () ->
+      Lwt_unix.send socket (Cstruct.to_bytes tx) 0
+        (Cstruct.len tx) [] >>= fun res ->
+      if res <> Cstruct.len tx then begin
+        safe_close socket >>= fun () ->
+        Lwt_result.fail (`Msg ("oops" ^ (string_of_int res)))
+      end else
+        Lwt_result.return ())
+     (fun e ->
+        safe_close socket >|= fun () ->
+        Error (`Msg (Printexc.to_string e)))
 
   let recv socket =
     let open Lwt in
     let recv_buffer = Bytes.make 2048 '\000' in
-    Lwt_unix.recv socket recv_buffer 0 (Bytes.length recv_buffer) []
-    >>= fun read_len ->
-    let open Lwt_result in
-    (if read_len > 0 then Lwt_result.return ()
-     else Lwt_result.fail (`Msg "Empty response")) >|= fun () ->
-    (Cstruct.of_bytes ~len:read_len recv_buffer)
+    Lwt.catch (fun () ->
+      Lwt_unix.recv socket recv_buffer 0 (Bytes.length recv_buffer) []
+      >>= fun read_len ->
+      if read_len > 0 then
+        Lwt_result.return (Cstruct.of_bytes ~len:read_len recv_buffer)
+      else begin
+        safe_close socket >>= fun () ->
+        Lwt_result.fail (`Msg "Empty response")
+      end)
+    (fun e ->
+       safe_close socket >>= fun () ->
+       Lwt_result.fail (`Msg (Printexc.to_string e)))
+
+  let close socket =
+    safe_close socket >|= fun () ->
+    Ok ()
 
   let map = Lwt_result.bind
   let resolve = Lwt_result.bind_result
@@ -59,8 +77,12 @@ module Uflow : Dns_client_flow.S
     end >>= fun (proto_number, socket_type) ->
     let socket = Lwt_unix.socket PF_INET socket_type proto_number in
     let addr = Lwt_unix.ADDR_INET (server, port) in
-    Lwt_unix.connect socket addr >|= fun () ->
-    Ok socket
+    Lwt.catch (fun () ->
+      Lwt_unix.connect socket addr >|= fun () ->
+      Ok socket)
+    (fun e ->
+      safe_close socket >|= fun () ->
+      Error (`Msg (Printexc.to_string e)))
 end
 
 (* Now that we have our {!Uflow} implementation we can include the logic


### PR DESCRIPTION
Dns_*client*: provide close, and close on error to avoid file descriptor leaks

atm, the definition of `type (+'ok,+'err) io` and `map` make it impossible to handle potential `recv`/`send` errors within Dns_client_flow (i.e. tear down/close the socket). if it'd be `type +a io` (and `map` being common Lwt.bind, i.e. the result type being external), this would be easier to do. WDYT?