### PR TITLE
Dns_client: revise "io" type (be polymorphic only in 'a, not in ('a, 'b))

### DIFF
--- a/client/dns_client_flow.ml
+++ b/client/dns_client_flow.ml
@@ -1,6 +1,6 @@
 module type S = sig
   type flow
-  type (+'a,+'b) io constraint 'b = [> `Msg of string]
+  type +'a io
   type io_addr
   type ns_addr = ([`TCP | `UDP]) * io_addr
   type stack
@@ -10,13 +10,13 @@ module type S = sig
 
   val nameserver : t -> ns_addr
 
-  val connect : ?nameserver:ns_addr -> t -> (flow,'err) io
-  val send : flow -> Cstruct.t -> (unit,'b) io
-  val recv : flow -> (Cstruct.t, 'b) io
+  val connect : ?nameserver:ns_addr -> t -> (flow, [> `Msg of string ]) result io
+  val send : flow -> Cstruct.t -> (unit, [> `Msg of string ]) result io
+  val recv : flow -> (Cstruct.t, [> `Msg of string ]) result io
+  val close : flow -> unit io
 
-  val resolve : ('a,'b) io -> ('a -> ('c,'b) result) -> ('c,'b) io
-  val map : ('a,'b) io -> ('a -> ('c,'b) io) -> ('c,'b) io
-  val lift : ('a,'b) result -> ('a,'b) io
+  val bind : 'a io -> ('a -> 'b io) -> 'b io
+  val lift : 'a -> 'a io
 end
 
 module Make = functor (Uflow:S) ->
@@ -26,42 +26,51 @@ struct
 
   let nameserver t = Uflow.nameserver t
 
+  let (>>=) = Uflow.bind
+
+  (* result-bind *)
+  let (>>|) a b =
+    a >>= function
+    | Ok a' -> b a'
+    | Error e -> Uflow.lift (Error e)
+
+  (* result-bind-and-lift *)
+  let (>>|=) a f = a >>| fun b -> Uflow.lift (f b)
+
   let getaddrinfo (type requested) t ?nameserver (query_type:requested Dns.Rr_map.key) name
-    : (requested, [> `Msg of string]) Uflow.io =
+    : (requested, [> `Msg of string]) result Uflow.io =
     let proto, _ = match nameserver with None -> Uflow.nameserver t | Some x -> x in
     let tx, state =
       Dns_client.make_query
         (match proto with `UDP -> `Udp | `TCP -> `Tcp) name query_type
     in
-    let (>>|) = Uflow.map in
     Uflow.connect ?nameserver t >>| fun socket ->
     Logs.debug (fun m -> m "Connected to NS.");
-    Uflow.send socket tx >>| fun () ->
-    let () = Logs.debug (fun m -> m "Receiving from NS") in
-    let rec recv_loop acc =
-      Uflow.recv socket >>| fun recv_buffer ->
-      Logs.debug (fun m -> m "Read @[<v>%d bytes@]"
-                     (Cstruct.len recv_buffer)) ;
-      let buf = Cstruct.append acc recv_buffer in
-      match Dns_client.parse_response state buf with
-      | Ok x -> Uflow.lift (Ok x)
-      | Error (`Msg xxx) ->
-        Uflow.lift (Error (`Msg( "err: " ^ xxx)))
-      | Error `Partial -> begin match proto with
-          | `TCP -> recv_loop buf
-          | `UDP -> Uflow.lift (Error (`Msg "Truncated UDP response")) end
-    in recv_loop Cstruct.empty
+    (Uflow.send socket tx >>| fun () ->
+     Logs.debug (fun m -> m "Receiving from NS");
+     let rec recv_loop acc =
+       Uflow.recv socket >>| fun recv_buffer ->
+       Logs.debug (fun m -> m "Read @[<v>%d bytes@]"
+                      (Cstruct.len recv_buffer)) ;
+       let buf = Cstruct.append acc recv_buffer in
+       match Dns_client.parse_response state buf with
+       | Ok x -> Uflow.lift (Ok x)
+       | Error (`Msg xxx) -> Uflow.lift (Error (`Msg( "err: " ^ xxx)))
+       | Error `Partial -> begin match proto with
+           | `TCP -> recv_loop buf
+           | `UDP -> Uflow.lift (Error (`Msg "Truncated UDP response")) end
+    in recv_loop Cstruct.empty) >>= fun r ->
+    Uflow.close socket >>= fun () ->
+    Uflow.lift r
 
   let gethostbyname stack ?nameserver domain =
-    let (>>=) = Uflow.resolve in
-    getaddrinfo stack ?nameserver Dns.Rr_map.A domain >>= fun (_ttl, resp) ->
+    getaddrinfo stack ?nameserver Dns.Rr_map.A domain >>|= fun (_ttl, resp) ->
     match Dns.Rr_map.Ipv4_set.choose_opt resp with
     | None -> Error (`Msg "No A record found")
     | Some ip -> Ok ip
 
   let gethostbyname6 stack ?nameserver domain =
-    let (>>=) = Uflow.resolve in
-    getaddrinfo stack ?nameserver Dns.Rr_map.Aaaa domain >>= fun (_ttl, res) ->
+    getaddrinfo stack ?nameserver Dns.Rr_map.Aaaa domain >>|= fun (_ttl, res) ->
     match Dns.Rr_map.Ipv6_set.choose_opt res with
     | None -> Error (`Msg "No AAAA record found")
     | Some ip -> Ok ip

--- a/lwt/client/dns_client_lwt.ml
+++ b/lwt/client/dns_client_lwt.ml
@@ -8,14 +8,13 @@ open Lwt.Infix
 module Uflow : Dns_client_flow.S
   with type flow = Lwt_unix.file_descr
  and type io_addr = Lwt_unix.inet_addr * int
- and type (+'a,+'b) io = ('a,'b) Lwt_result.t
+ and type +'a io = 'a Lwt.t
  and type stack = unit
 = struct
   type io_addr = Lwt_unix.inet_addr * int
   type flow = Lwt_unix.file_descr
   type ns_addr = [`TCP | `UDP] * io_addr
-  type (+'a,+'b) io = ('a,'b) Lwt_result.t
-    constraint 'b = [> `Msg of string]
+  type +'a io = 'a Lwt.t
   type stack = unit
   type t = { nameserver : ns_addr }
 
@@ -24,28 +23,34 @@ module Uflow : Dns_client_flow.S
 
   let nameserver { nameserver } = nameserver
 
+  let close socket =
+    Lwt.catch (fun () -> Lwt_unix.close socket) (fun _ -> Lwt.return_unit)
+
   let send socket tx =
     let open Lwt in
-    Lwt_unix.send socket (Cstruct.to_bytes tx) 0
-      (Cstruct.len tx) [] >>= fun res ->
-    if res <> Cstruct.len tx then
-      Lwt_result.fail (`Msg ("oops" ^ (string_of_int res)))
-    else
-      Lwt_result.return ()
+    Lwt.catch (fun () ->
+      Lwt_unix.send socket (Cstruct.to_bytes tx) 0
+        (Cstruct.len tx) [] >>= fun res ->
+      if res <> Cstruct.len tx then
+        Lwt_result.fail (`Msg ("oops" ^ (string_of_int res)))
+      else
+        Lwt_result.return ())
+     (fun e -> Lwt.return (Error (`Msg (Printexc.to_string e))))
 
   let recv socket =
     let open Lwt in
     let recv_buffer = Bytes.make 2048 '\000' in
-    Lwt_unix.recv socket recv_buffer 0 (Bytes.length recv_buffer) []
-    >>= fun read_len ->
-    let open Lwt_result in
-    (if read_len > 0 then Lwt_result.return ()
-     else Lwt_result.fail (`Msg "Empty response")) >|= fun () ->
-    (Cstruct.of_bytes ~len:read_len recv_buffer)
+    Lwt.catch (fun () ->
+      Lwt_unix.recv socket recv_buffer 0 (Bytes.length recv_buffer) []
+      >>= fun read_len ->
+      if read_len > 0 then
+        Lwt_result.return (Cstruct.of_bytes ~len:read_len recv_buffer)
+      else
+        Lwt_result.fail (`Msg "Empty response"))
+    (fun e -> Lwt_result.fail (`Msg (Printexc.to_string e)))
 
-  let map = Lwt_result.bind
-  let resolve = Lwt_result.bind_result
-  let lift = Lwt_result.lift
+  let bind = Lwt.bind
+  let lift = Lwt.return
 
   let connect ?nameserver:ns t =
     let (proto, (server, port)) = match ns with None -> nameserver t | Some x -> x in
@@ -59,8 +64,12 @@ module Uflow : Dns_client_flow.S
     end >>= fun (proto_number, socket_type) ->
     let socket = Lwt_unix.socket PF_INET socket_type proto_number in
     let addr = Lwt_unix.ADDR_INET (server, port) in
-    Lwt_unix.connect socket addr >|= fun () ->
-    Ok socket
+    Lwt.catch (fun () ->
+      Lwt_unix.connect socket addr >|= fun () ->
+      Ok socket)
+    (fun e ->
+      close socket >|= fun () ->
+      Error (`Msg (Printexc.to_string e)))
 end
 
 (* Now that we have our {!Uflow} implementation we can include the logic

--- a/lwt/client/dns_client_lwt.mli
+++ b/lwt/client/dns_client_lwt.mli
@@ -8,7 +8,7 @@
 module Uflow : Dns_client_flow.S
   with type flow = Lwt_unix.file_descr
    and type io_addr = Lwt_unix.inet_addr * int
-   and type (+'a,+'b) io = ('a,'b) Lwt_result.t
+   and type +'a io = 'a Lwt.t
    and type stack = unit
 
 include module type of Dns_client_flow.Make(Uflow)

--- a/mirage/client/dns_mirage_client.ml
+++ b/mirage/client/dns_mirage_client.ml
@@ -8,15 +8,13 @@ module Make (S : Mirage_stack_lwt.V4) = struct
   module Uflow : Dns_client_flow.S
     with type flow = S.TCPV4.flow
      and type stack = S.t
-     and type (+'a,+'b) io = ('a, 'b) Lwt_result.t
-           constraint 'b = [> `Msg of string]
+     and type +'a io = 'a Lwt.t
      and type io_addr = Ipaddr.V4.t * int = struct
     type flow = S.TCPV4.flow
     type stack = S.t
     type io_addr = Ipaddr.V4.t * int
     type ns_addr = [`TCP | `UDP] * io_addr
-    type (+'a,+'b) io = ('a, 'b) Lwt_result.t
-      constraint 'b = [> `Msg of string]
+    type +'a io = 'a Lwt.t
     type t = {
       nameserver : ns_addr ;
       stack : stack ;
@@ -27,9 +25,8 @@ module Make (S : Mirage_stack_lwt.V4) = struct
 
     let nameserver { nameserver ; _ } = nameserver
 
-    let map = Lwt_result.bind
-    let resolve = Lwt_result.bind_result
-    let lift = Lwt_result.lift
+    let bind = Lwt.bind
+    let lift = Lwt.return
 
     let connect ?nameserver:ns t =
       let _proto, addr = match ns with None -> nameserver t | Some x -> x in
@@ -39,6 +36,8 @@ module Make (S : Mirage_stack_lwt.V4) = struct
                     S.TCPV4.pp_error e) ;
         Error (`Msg "connect failure")
       | Ok flow -> Ok flow
+
+    let close f = S.TCPV4.close f
 
     let recv flow =
       S.TCPV4.read flow >|= function

--- a/mirage/client/dns_mirage_client.mli
+++ b/mirage/client/dns_mirage_client.mli
@@ -3,7 +3,7 @@ module Make (S : Mirage_stack_lwt.V4) : sig
   module Uflow : Dns_client_flow.S
     with type flow = S.TCPV4.flow
      and type io_addr = Ipaddr.V4.t * int
-     and type (+'a, +'b) io = ('a, 'b) Lwt_result.t
+     and type +'a io = 'a Lwt.t
      and type stack = S.t
 
   include module type of Dns_client_flow.Make(Uflow)

--- a/unix/client/dns_client_unix.ml
+++ b/unix/client/dns_client_unix.ml
@@ -7,25 +7,26 @@ module Uflow : Dns_client_flow.S
   with type flow = Unix.file_descr
    and type io_addr = Unix.inet_addr * int
    and type stack = unit
-   and type (+'a,+'b) io = ('a,[> `Msg of string]as 'b) result
+   and type +'a io = 'a
 = struct
   type io_addr = Unix.inet_addr * int
   type ns_addr = [`TCP | `UDP] * io_addr
   type stack = unit
   type flow = Unix.file_descr
   type t = { nameserver : ns_addr }
-  type (+'a,+'b) io = ('a,'b) result constraint 'b = [> `Msg of string]
+  type +'a io = 'a
 
   let create ?(nameserver = `TCP, (Unix.inet_addr_of_string "91.239.100.100", 53)) () =
     { nameserver }
 
   let nameserver { nameserver } = nameserver
 
-  let map = Rresult.R.((>>=))
-  let resolve = (Rresult.R.(>>=))
+  let bind a b = b a
   let lift v = v
 
   open Rresult
+
+  let close socket = try Unix.close socket with _ -> ()
 
   let connect ?nameserver:ns t =
     let proto, (server, port) = match ns with None -> nameserver t | Some x -> x in
@@ -35,23 +36,34 @@ module Uflow : Dns_client_flow.S
     end >>= fun proto_number ->
     let socket = Unix.socket PF_INET SOCK_STREAM proto_number in
     let addr = Unix.ADDR_INET (server, port) in
-    Unix.connect socket addr ;
-    Ok socket
+    try
+      Unix.connect socket addr ;
+      Ok socket
+    with e ->
+      close socket ;
+      Error (`Msg (Printexc.to_string e))
 
   let send (socket:flow) (tx:Cstruct.t) =
     let str = Cstruct.to_string tx in
-    let res = Unix.send_substring socket str 0 (String.length str) [] in
-    if res <> String.length str
-    then Error (`Msg ("Broken write to upstream NS" ^ (string_of_int res)))
-    else Ok ()
+    try
+      let res = Unix.send_substring socket str 0 (String.length str) [] in
+      if res <> String.length str
+      then
+        Error (`Msg ("Broken write to upstream NS" ^ (string_of_int res)))
+      else Ok ()
+   with e ->
+     Error (`Msg (Printexc.to_string e))
 
   let recv (socket:flow) =
     let buffer = Bytes.make 2048 '\000' in
-    let x = Unix.recv socket buffer 0 (Bytes.length buffer) [] in
-    if x > 0 && x <= Bytes.length buffer then
-      Ok (Cstruct.of_bytes buffer ~len:x)
-    else
-      Error (`Msg "Reading from NS socket failed")
+    try
+      let x = Unix.recv socket buffer 0 (Bytes.length buffer) [] in
+      if x > 0 && x <= Bytes.length buffer then
+        Ok (Cstruct.of_bytes buffer ~len:x)
+      else
+        Error (`Msg "Reading from NS socket failed")
+    with e ->
+      Error (`Msg (Printexc.to_string e))
 end
 
 (* Now that we have our {!Uflow} implementation we can include the logic

--- a/unix/client/dns_client_unix.mli
+++ b/unix/client/dns_client_unix.mli
@@ -8,6 +8,6 @@ module Uflow : Dns_client_flow.S
   with type flow = Unix.file_descr
    and type io_addr = Unix.inet_addr * int
    and type stack = unit
-   and type (+'a,+'b) io = ('a,'b) result
+   and type +'a io = 'a
 
 include module type of Dns_client_flow.Make(Uflow)


### PR DESCRIPTION
Dns_client_flow: require "close : flow -> unit io" to close a flow
Dns_*client*: provide close, and close on error to avoid file descriptor leaks

this is meant as alternative to #181