### PR TITLE
server outgoing signature changes

### DIFF
--- a/dns-server.opam
+++ b/dns-server.opam
@@ -15,6 +15,7 @@ depends: [
   "duration"
   "alcotest" {with-test}
   "nocrypto" {with-test}
+  "dns-tsig" {with-test}
 ]
 
 build: [

--- a/mirage/dns_mirage.ml
+++ b/mirage/dns_mirage.ml
@@ -76,6 +76,13 @@ module Make (S : Mirage_stack_lwt.V4) = struct
       T.close flow >|= fun () ->
       Error ()
 
+  let send_tcp_multiple flow datas =
+    Lwt_list.fold_left_s (fun acc d ->
+        match acc with
+        | Error () -> Lwt.return (Error ())
+        | Ok () -> send_tcp flow d)
+      (Ok ()) datas
+
   let read_tcp flow =
     read_exactly flow 2 >>= function
     | Error () -> Lwt.return (Error ())

--- a/mirage/dns_mirage.mli
+++ b/mirage/dns_mirage.mli
@@ -32,7 +32,12 @@ module Make (S : Mirage_stack_lwt.V4) : sig
 
   val send_tcp : S.TCPV4.flow -> Cstruct.t -> (unit, unit) result Lwt.t
   (** [send_tcp flow buf] sends the buffer, either succeeds or fails (logs
-     actual error). *)
+      actual error). *)
+
+  val send_tcp_multiple : S.TCPV4.flow -> Cstruct.t list ->
+    (unit, unit) result Lwt.t
+  (** [send_tcp_multiple flow bufs] sends the buffers, either succeeds or fails
+      (logs actual error). *)
 
   val send_udp : S.t -> int -> Ipaddr.V4.t -> int -> Cstruct.t -> unit Lwt.t
   (** [send_udp stack source_port dst dst_port buf] sends the [buf] as UDP

--- a/server/dns_server.mli
+++ b/server/dns_server.mli
@@ -127,20 +127,20 @@ module Secondary : sig
 
   val handle_packet : s -> Ptime.t -> int64 -> Ipaddr.V4.t ->
     Packet.t -> 'a Domain_name.t option ->
-    s * Packet.t option * (proto * Ipaddr.V4.t * Cstruct.t) list
+    s * Packet.t option * (Ipaddr.V4.t * Cstruct.t) option
   (** [handle_packet s now ts ip proto key t] handles the incoming packet. *)
 
   val handle_buf : s -> Ptime.t -> int64 -> proto -> Ipaddr.V4.t -> Cstruct.t ->
-    s * Cstruct.t option * (proto * Ipaddr.V4.t * Cstruct.t) list
+    s * Cstruct.t option * (Ipaddr.V4.t * Cstruct.t) option
   (** [handle_buf s now ts proto src buf] decodes [buf], processes with
       {!handle_packet}, and encodes the results. *)
 
   val timer : s -> Ptime.t -> int64 ->
-    s * (proto * Ipaddr.V4.t * Cstruct.t) list
+    s * (Ipaddr.V4.t * Cstruct.t list) list
   (** [timer s now ts] may request SOA or retransmit AXFR. *)
 
   val closed : s -> Ptime.t -> int64 -> Ipaddr.V4.t ->
-    s * (proto * Ipaddr.V4.t * Cstruct.t) list
-  (** [closed s now ts ip] marks [ip] as closed. *)
-
+    s * Cstruct.t list
+  (** [closed s now ts ip] marks [ip] as closed, the returned buffers (SOA
+      requests) should be sent to [ip]. *)
 end

--- a/server/dns_server.mli
+++ b/server/dns_server.mli
@@ -62,12 +62,12 @@ module Primary : sig
   (** [data s] is the data store of [s]. *)
 
   val with_data : s -> Ptime.t -> int64 -> Dns_trie.t ->
-    s * (Ipaddr.V4.t * Cstruct.t) list
+    s * (Ipaddr.V4.t * Cstruct.t list) list
   (** [with_data s now ts trie] replaces the current data with [trie] in [s].
       The returned notifications should be send out. *)
 
   val with_keys : s -> Ptime.t -> int64 -> ('a Domain_name.t * Dnskey.t) list ->
-    s * (Ipaddr.V4.t * Cstruct.t) list
+    s * (Ipaddr.V4.t * Cstruct.t list) list
   (** [with_keys s now ts keys] replaces the current keys with [keys] in [s],
       and generates notifications. *)
 
@@ -79,7 +79,7 @@ module Primary : sig
 
   val handle_packet : s -> Ptime.t -> int64 -> proto -> Ipaddr.V4.t -> int ->
     Packet.t -> 'a Domain_name.t option ->
-    s * Packet.t option * (Ipaddr.V4.t * Cstruct.t) list *
+    s * Packet.t option * (Ipaddr.V4.t * Cstruct.t list) list *
     [> `Notify of Soa.t option | `Keep ] option
   (** [handle_packet s now ts src src_port proto key packet] handles the given
      [packet], returning new state, an answer, and potentially notify packets to
@@ -87,7 +87,7 @@ module Primary : sig
 
   val handle_buf : s -> Ptime.t -> int64 -> proto ->
     Ipaddr.V4.t -> int -> Cstruct.t ->
-    s * Cstruct.t option * (Ipaddr.V4.t * Cstruct.t) list *
+    s * Cstruct.t option * (Ipaddr.V4.t * Cstruct.t list) list *
     [ `Notify of Soa.t option | `Signed_notify of Soa.t option | `Keep ] option
   (** [handle_buf s now ts proto src src_port buffer] decodes the [buffer],
      processes the DNS frame using {!handle_packet}, and encodes the reply. *)
@@ -95,7 +95,8 @@ module Primary : sig
   val closed : s -> Ipaddr.V4.t -> s
   (** [closed s ip] marks the connection to [ip] closed. *)
 
-  val timer : s -> Ptime.t -> int64 -> s * (Ipaddr.V4.t * Cstruct.t) list
+  val timer : s -> Ptime.t -> int64 ->
+    s * (Ipaddr.V4.t * Cstruct.t list) list
   (** [timer s now ts] may encode some notifications to secondary name servers
      if previous ones were not acknowledged. *)
 
@@ -105,7 +106,6 @@ module Primary : sig
      tsig key name of the servers to be notified for a zone change.  This list
      is based on (a) NS entries for the zone, (b) registered TSIG transfer keys,
      and (c) active connection (which transmitted a signed SOA). *)
-
 end
 
 module Secondary : sig

--- a/test/dune
+++ b/test/dune
@@ -7,7 +7,7 @@
 (test
  (name server)
  (package dns-server)
- (libraries dns-server alcotest nocrypto.unix)
+ (libraries dns-server dns-tsig alcotest nocrypto.unix)
  (modules server))
 
 (test


### PR DESCRIPTION
we used to accumulate hacks and further maps and workaround just to ensure that "to each IP address, establish a single connection" -- esp. at startup of the primary (where it may want to inform a single IP about 100 zones; or when it received a signed SOA request (with a root key) for the root zone, replying with NOTIFY for all authoritative zones) and secondary (where it may want to request the SOA of a single primary for multiple zones). now, instead of having the result `(ip * cstruct.t) list`, using `(ip * cstruct.t list) list` allows the effectful layer to send all the notify/requests to that single ip address at once! (i.e. no fold and establish connections necessary :)

similarly, the secondary API got slightly revised, turns out `handle_*` may only ever result in _one_ reply and _optionally_ _one_ other packet to the authoritative (i.e. when a notify is received, a notify_ack is replied with, and a SOA request is sent (or directly ixfr/axfr if the notify contained a signed soa)).

now, the ad-hoc `tcp_packet_transit` map is gone, there are retransmissions in the `timer` function which care exactly about that (that something is sent, but not acknowledged on the protocol level).

this cleans up #169 and #170, could get some unit tests about the above described startup and update struggle, and looks to me as the last blocker of a release.

@cfcs if you could review this as now, that'd be great. i'll surely push some more documentation and unit tests directly on this PR before merging, think a bit more, and likely tag a release (unless you find blockers -- i guess #165 would be good to have fixed as well, I'll propose in a separate PR in a few minutes).