### PR TITLE
client: use Randomconv.int16, provide rng via create

### DIFF
--- a/client/dns_client.ml
+++ b/client/dns_client.ml
@@ -6,13 +6,13 @@ type 'key query_state =
     query : Packet.t ;
   } constraint 'key = 'a Rr_map.key
 
-let make_query protocol hostname
+let make_query rng protocol hostname
     : 'xy  ->
       Cstruct.t * 'xy query_state =
   (* SRV records: Service + Protocol are case-insensitive, see RFC2728 pg2. *)
   fun record_type ->
   let question = Packet.Question.create hostname record_type in
-  let header = Random.int 0xffff (* TODO *), Packet.Flags.singleton `Recursion_desired in
+  let header = Randomconv.int16 rng, Packet.Flags.singleton `Recursion_desired in
   let query = Packet.create header question `Query in
   let cs , _ = Packet.encode protocol query in
   begin match protocol with

--- a/client/dns_client.mli
+++ b/client/dns_client.mli
@@ -18,18 +18,12 @@ type 'key query_state constraint 'key = 'a Dns.Rr_map.key
 *)
 
 val make_query :
-  Dns.proto -> 'a Domain_name.t ->
+  (int -> Cstruct.t) -> Dns.proto -> 'a Domain_name.t ->
   'query_type Dns.Rr_map.key ->
   Cstruct.t * 'query_type Dns.Rr_map.key query_state
-(** [make_query protocol name query_type] is [query, query_state]
+(** [make_query rng protocol name query_type] is [query, query_state]
     where [query] is the serialized DNS query to send to the name server,
-    and [query_state] is the information required to validate the response.
-
-    NB: When querying for [TLSA] records, it is important to use the optional
-    [~hostname:false] parameter with the conversion functions within {!Domain_name}
-    when constructing the {!Domain_name.t} for the search, since these contain
-    labels prefixed with underscores.
-*)
+    and [query_state] is the information required to validate the response. *)
 
 val parse_response : 'query_type Dns.Rr_map.key query_state -> Cstruct.t ->
   ('query_type, [`Msg of string | `Partial]) result

--- a/dns-mirage-client.opam
+++ b/dns-mirage-client.opam
@@ -18,6 +18,7 @@ depends: [
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "3.0.0"}
   "mirage-stack-lwt"
+  "mirage-random"
   "dns-client" {= version}
 ]
 synopsis: "DNS client library for MirageOS"

--- a/lwt/client/dns_client_lwt.ml
+++ b/lwt/client/dns_client_lwt.ml
@@ -16,12 +16,18 @@ module Uflow : Dns_client_flow.S
   type ns_addr = [`TCP | `UDP] * io_addr
   type +'a io = 'a Lwt.t
   type stack = unit
-  type t = { nameserver : ns_addr }
+  type t = {
+    rng : (int -> Cstruct.t) ;
+    nameserver : ns_addr ;
+  }
 
-  let create ?(nameserver = `TCP, (Unix.inet_addr_of_string "91.239.100.100", 53)) () =
-    { nameserver }
+  let create
+    ?(rng = Dns_client_flow.stdlib_random)
+    ?(nameserver = `TCP, (Unix.inet_addr_of_string "91.239.100.100", 53)) () =
+    { rng ; nameserver }
 
-  let nameserver { nameserver } = nameserver
+  let nameserver { nameserver ; _ } = nameserver
+  let rng { rng ; _ } = rng
 
   let close socket =
     Lwt.catch (fun () -> Lwt_unix.close socket) (fun _ -> Lwt.return_unit)

--- a/mirage/client/dns_mirage_client.mli
+++ b/mirage/client/dns_mirage_client.mli
@@ -1,5 +1,5 @@
 
-module Make (S : Mirage_stack_lwt.V4) : sig
+module Make (R : Mirage_random.C) (S : Mirage_stack_lwt.V4) : sig
   module Uflow : Dns_client_flow.S
     with type flow = S.TCPV4.flow
      and type io_addr = Ipaddr.V4.t * int

--- a/mirage/client/dune
+++ b/mirage/client/dune
@@ -1,6 +1,6 @@
 (library
   (name        dns_mirage_client)
   (public_name dns-mirage-client)
-  (libraries   domain-name ipaddr mirage-stack-lwt dns-client)
+  (libraries   domain-name ipaddr mirage-random mirage-stack-lwt dns-client)
   (wrapped     false)
 )

--- a/unix/client/dns_client_unix.ml
+++ b/unix/client/dns_client_unix.ml
@@ -13,13 +13,19 @@ module Uflow : Dns_client_flow.S
   type ns_addr = [`TCP | `UDP] * io_addr
   type stack = unit
   type flow = Unix.file_descr
-  type t = { nameserver : ns_addr }
+  type t = {
+    rng : int -> Cstruct.t ;
+    nameserver : ns_addr ;
+  }
   type +'a io = 'a
 
-  let create ?(nameserver = `TCP, (Unix.inet_addr_of_string "91.239.100.100", 53)) () =
-    { nameserver }
+  let create
+      ?(rng = Dns_client_flow.stdlib_random)
+      ?(nameserver = `TCP, (Unix.inet_addr_of_string "91.239.100.100", 53)) () =
+    { rng ; nameserver }
 
-  let nameserver { nameserver } = nameserver
+  let nameserver { nameserver ; _ } = nameserver
+  let rng { rng ; _ } = rng
 
   let bind a b = b a
   let lift v = v


### PR DESCRIPTION
this is a solution for #165 -- another could be to fully functorize over Mirage_random.C (but that'd bring us a Mirage_random dependency in the pure client, which I'd avoid) -- let me know what you think about this! :)