### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/dns.opam
+++ b/dns.opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 license: "BSD2"
 
 depends: [
-  "dune" {build & >= "1.2.0"}
+  "dune" {>= "1.2.0"}
   "ocaml" {>= "4.07.0"}
   "rresult" "astring" "fmt" "logs" "ptime"
   "domain-name" {>= "0.3.0"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.