### PR TITLE
provide statistics in dns-server.mirage

### DIFF
--- a/dns-server.opam
+++ b/dns-server.opam
@@ -21,6 +21,7 @@ depends: [
   "nocrypto" {with-test}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
+  "metrics"
 ]
 
 build: [

--- a/mirage/dns_mirage.ml
+++ b/mirage/dns_mirage.ml
@@ -45,7 +45,7 @@ module Make (S : Mirage_stack.V4) = struct
     else
       T.read f.flow >>= function
       | Ok `Eof ->
-        Log.warn (fun m -> m "end of file on flow %a:%d" Ipaddr.V4.pp dst_ip dst_port) ;
+        Log.debug (fun m -> m "end of file on flow %a:%d" Ipaddr.V4.pp dst_ip dst_port) ;
         T.close f.flow >>= fun () ->
         Lwt.return (Error ())
       | Error e ->
@@ -57,7 +57,7 @@ module Make (S : Mirage_stack.V4) = struct
         read_exactly f length
 
   let send_udp stack src_port dst dst_port data =
-    Log.info (fun m -> m "udp: sending %d bytes from %d to %a:%d"
+    Log.debug (fun m -> m "udp: sending %d bytes from %d to %a:%d"
                  (Cstruct.len data) src_port Ipaddr.V4.pp dst dst_port) ;
     U.write ~src_port ~dst ~dst_port (S.udpv4 stack) data >|= function
     | Error e -> Log.warn (fun m -> m "udp: failure %a while sending from %d to %a:%d"
@@ -66,7 +66,7 @@ module Make (S : Mirage_stack.V4) = struct
 
   let send_tcp flow answer =
     let dst_ip, dst_port = T.dst flow in
-    Log.info (fun m -> m "tcp: sending %d bytes to %a:%d" (Cstruct.len answer) Ipaddr.V4.pp dst_ip dst_port) ;
+    Log.debug (fun m -> m "tcp: sending %d bytes to %a:%d" (Cstruct.len answer) Ipaddr.V4.pp dst_ip dst_port) ;
     let len = Cstruct.create 2 in
     Cstruct.BE.set_uint16 len 0 (Cstruct.len answer) ;
     T.write flow (Cstruct.append len answer) >>= function

--- a/mirage/server/dune
+++ b/mirage/server/dune
@@ -2,4 +2,4 @@
  (name dns_server_mirage)
  (public_name dns-server.mirage)
  (wrapped false)
- (libraries dns dns-server dns-mirage lwt duration randomconv mirage-time mirage-clock mirage-stack))
+ (libraries dns dns-server dns-mirage lwt duration randomconv mirage-time mirage-clock mirage-stack metrics))


### PR DESCRIPTION
at some point, the `counter_metrics` should be provided elsewhere (in metrics itself?), but for now this should be fine. //cc @cfcs