### PR TITLE
Dns_server.handle_buf: expose (optional) key name used to authenticate an update

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ You may want to follow the [mirage installation
 instructions](https://mirage.io/wiki/install) to get `mirage` installed on your
 computer.
 
-To lower the amount of run-time dependencies for each individual functionality,
-the library is split across a number of opam packages.
-
-µDNS is not released yet, but you can install it and its dependencies via opam,
-see [Development](#Development).
+To minimize the amount of run-time dependencies for each individual
+functionality, the library is split into multiple opam packages (core, server,
+client, resolver, cli, certify), with multiple ocamlfind libraries for the
+different backends (no optional dependencies) -- i.e. `dns-server.mirage`
+contains the MirageOS-specific DNS server code.
 
 Now the µDNS library is installed, and you can try out the examples.  Find some
 examples at the [unikernel repository](https://github.com/roburio/unikernels).
@@ -103,12 +103,11 @@ stricter coding style used in the post-4.0.0 branches.  The major improvements
 from 1.x to the 4.x series are:
 
 - data (rrset) is defined in a single GADT in `Rr_map`
-- add support for: notify, dynamic update, zone transfer, tsig (hmac authentication), edns
-- no mutable datastructures to make reasoning about library state easier
-- switches to an independent `domain_name` library which uses a faster and more
+- added support for: notify, dynamic update, zone transfer, tsig (hmac authentication), edns
+- no mutable data structures, leading to easier reasoning about library state
+- switched to an independent `domain_name` library which uses a faster and more
   compact `string array` instead of `string list` for storing domain names
 - integration with LetsEncrypt for provisioning valid X.509 certificates
-- more strict hostname validation
 - no use of exceptions, instead preferring explicit result values from API functions
 
 Please get in touch on <mirageos-devel@lists.xenproject.org> or on the Discuss forum
@@ -123,7 +122,7 @@ you will have to pin the same *version* for all of them:
 
 ```csh
 : csh syntax
-set version=4.0.0
+set version=4.99.0
 set repo=git+https://github.com/mirage/ocaml-dns.git
 
 # the -y parameter means "force" or
@@ -139,7 +138,7 @@ end
 
 ```bash
 : bash syntax
-version=4.0.0
+version=4.99.0
 repo=git+https://github.com/mirage/ocaml-dns.git
 
 for pkg in dns dns-{certify,cli,client,resolver,server,mirage,tsig}

--- a/mirage/server/dns_server_mirage.ml
+++ b/mirage/server/dns_server_mirage.ml
@@ -45,7 +45,7 @@ module Make (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (TIME : Mirage_t
     let src = counter_metrics ~f "dns-server-mirage" in
     (fun x -> Metrics.add src (fun x -> x) (fun d -> d x))
 
-  let primary ?(on_update = fun ~old:_ _ _ _ -> Lwt.return_unit) ?(on_notify = fun _ _ -> Lwt.return None) ?(timer = 2) ?(port = 53) stack t =
+  let primary ?(on_update = fun ~old:_ ~authenticated_key:_ ~update_source:_ _ -> Lwt.return_unit) ?(on_notify = fun _ _ -> Lwt.return None) ?(timer = 2) ?(port = 53) stack t =
     let state = ref t in
     let tcp_out = ref Dns.IM.empty in
 
@@ -98,7 +98,7 @@ module Make (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (TIME : Mirage_t
       if Dns_trie.equal (trie t) (trie old) then
         Lwt.return_unit
       else begin
-        inc `On_update ; on_update ~old:(trie old) key ip t
+        inc `On_update ; on_update ~old:(trie old) ~authenticated_key:key ~update_source:ip t
       end
     and maybe_notify recv_task t now ts = function
       | None -> Lwt.return_unit

--- a/mirage/server/dns_server_mirage.mli
+++ b/mirage/server/dns_server_mirage.mli
@@ -8,9 +8,12 @@ module Make (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (T : Mirage_time
                 Dns_server.Primary.s ->
                 (Dns_trie.t * ([ `raw ] Domain_name.t * Dns.Dnskey.t) list) option Lwt.t) ->
     ?timer:int -> ?port:int -> S.t -> Dns_server.Primary.s -> unit
-  (** [primary ~on_update ~timer ~port stack primary] starts a primary server on [port]
-     (default 53, both TCP and UDP) with the given [primary] configuration. [timer] is the
-     DNS notify timer in seconds, and defaults to 2 seconds. *)
+  (** [primary ~on_update ~timer ~port stack primary] starts a primary server on
+     [port] (default 53, both TCP and UDP) with the given [primary]
+     configuration. [timer] is the DNS notify timer in seconds, and defaults to
+     2 seconds. [on_update ~old key ip s] is a callback if the data served by
+     the primary server got updated by a potentially authenticated nsupdate
+     packet, the used [key] and source [ip] are passed to the callback. *)
 
   val secondary :
     ?on_update:(old:Dns_trie.t -> Dns_server.Secondary.s -> unit Lwt.t) ->

--- a/mirage/server/dns_server_mirage.mli
+++ b/mirage/server/dns_server_mirage.mli
@@ -2,7 +2,8 @@
 
 module Make (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4) : sig
 
-  val primary : ?on_update:(old:Dns_trie.t -> Dns_server.Primary.s -> unit Lwt.t) ->
+  val primary :
+    ?on_update:(old:Dns_trie.t -> [`raw] Domain_name.t option -> Ipaddr.V4.t -> Dns_server.Primary.s -> unit Lwt.t) ->
     ?on_notify:([ `Notify of Dns.Soa.t option | `Signed_notify of Dns.Soa.t option ] ->
                 Dns_server.Primary.s ->
                 (Dns_trie.t * ([ `raw ] Domain_name.t * Dns.Dnskey.t) list) option Lwt.t) ->

--- a/mirage/server/dns_server_mirage.mli
+++ b/mirage/server/dns_server_mirage.mli
@@ -14,7 +14,10 @@ module Make (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (T : Mirage_time
      2 seconds. [on_update ~old ~authenticated_key ~update_source s] is a
      callback if the data served by the primary server [s] got updated by a
      potentially authenticated nsupdate packet, the used [authenticated_key]
-     and source [update_source] are passed to the callback. *)
+     and source [update_source] are passed to the callback. The
+     [on_notify notify s] callback is executed when a notify request is received
+     by the primary DNS server (may be used for signaling of a (hidden) DNS
+     secondary server). *)
 
   val secondary :
     ?on_update:(old:Dns_trie.t -> Dns_server.Secondary.s -> unit Lwt.t) ->

--- a/mirage/server/dns_server_mirage.mli
+++ b/mirage/server/dns_server_mirage.mli
@@ -3,7 +3,7 @@
 module Make (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4) : sig
 
   val primary :
-    ?on_update:(old:Dns_trie.t -> [`raw] Domain_name.t option -> Ipaddr.V4.t -> Dns_server.Primary.s -> unit Lwt.t) ->
+    ?on_update:(old:Dns_trie.t -> authenticated_key:[`raw] Domain_name.t option -> update_source:Ipaddr.V4.t -> Dns_server.Primary.s -> unit Lwt.t) ->
     ?on_notify:([ `Notify of Dns.Soa.t option | `Signed_notify of Dns.Soa.t option ] ->
                 Dns_server.Primary.s ->
                 (Dns_trie.t * ([ `raw ] Domain_name.t * Dns.Dnskey.t) list) option Lwt.t) ->
@@ -11,9 +11,10 @@ module Make (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (T : Mirage_time
   (** [primary ~on_update ~timer ~port stack primary] starts a primary server on
      [port] (default 53, both TCP and UDP) with the given [primary]
      configuration. [timer] is the DNS notify timer in seconds, and defaults to
-     2 seconds. [on_update ~old key ip s] is a callback if the data served by
-     the primary server got updated by a potentially authenticated nsupdate
-     packet, the used [key] and source [ip] are passed to the callback. *)
+     2 seconds. [on_update ~old ~authenticated_key ~update_source s] is a
+     callback if the data served by the primary server [s] got updated by a
+     potentially authenticated nsupdate packet, the used [authenticated_key]
+     and source [update_source] are passed to the callback. *)
 
   val secondary :
     ?on_update:(old:Dns_trie.t -> Dns_server.Secondary.s -> unit Lwt.t) ->

--- a/server/dns_server.ml
+++ b/server/dns_server.ml
@@ -991,7 +991,7 @@ module Primary = struct
       Log.warn (fun m -> m "error %a while %a sent %a, answering with %a"
                    Rcode.pp rcode Ipaddr.V4.pp ip Cstruct.hexdump_pp buf
                    Fmt.(option ~none:(unit "no") Cstruct.hexdump_pp) answer);
-      t, answer, [], None
+      t, answer, [], None, None
     | Ok p ->
       let handle_inner keyname =
         let t, answer, out, notify =
@@ -1016,14 +1016,14 @@ module Primary = struct
       match handle_tsig ?mac server now p buf with
       | Error (e, data) ->
         Log.err (fun m -> m "error %a while handling tsig" Tsig_op.pp_e e);
-        t, data, [], None
+        t, data, [], None, None
       | Ok None ->
         let t, answer, out, notify = handle_inner None in
         let answer' = match answer with
           | None -> None
           | Some (_, (cs, _)) -> Some cs
         in
-        (t, answer', out, notify)
+        t, answer', out, notify, None
       | Ok (Some (name, tsig, mac, key)) ->
         let n = function
           | Some (`Notify n) -> Some (`Signed_notify n)
@@ -1042,7 +1042,7 @@ module Primary = struct
               None
             | Some (buf, _) -> Some buf
         in
-        (t', answer', out, n notify)
+        t', answer', out, n notify, Some name
 
   let closed (t, m, l, ns) ip =
     let l' = Notification.remove l ip in

--- a/server/dns_server.mli
+++ b/server/dns_server.mli
@@ -91,7 +91,10 @@ module Primary : sig
     [ `Notify of Soa.t option | `Signed_notify of Soa.t option | `Keep ] option *
     [ `raw ] Domain_name.t option
   (** [handle_buf s now ts proto src src_port buffer] decodes the [buffer],
-     processes the DNS frame using {!handle_packet}, and encodes the reply. *)
+     processes the DNS frame using {!handle_packet}, and encodes the reply.
+     The result is a new state, potentially an answer to the requestor, a list
+     of notifications to send out, information whether a notify (or signed
+     notify) was received, and the hmac key used for authentication. *)
 
   val closed : s -> Ipaddr.V4.t -> s
   (** [closed s ip] marks the connection to [ip] closed. *)

--- a/server/dns_server.mli
+++ b/server/dns_server.mli
@@ -88,7 +88,8 @@ module Primary : sig
   val handle_buf : s -> Ptime.t -> int64 -> proto ->
     Ipaddr.V4.t -> int -> Cstruct.t ->
     s * Cstruct.t option * (Ipaddr.V4.t * Cstruct.t list) list *
-    [ `Notify of Soa.t option | `Signed_notify of Soa.t option | `Keep ] option
+    [ `Notify of Soa.t option | `Signed_notify of Soa.t option | `Keep ] option *
+    [ `raw ] Domain_name.t option
   (** [handle_buf s now ts proto src src_port buffer] decodes the [buffer],
      processes the DNS frame using {!handle_packet}, and encodes the reply. *)
 

--- a/server/dns_trie.ml
+++ b/server/dns_trie.ml
@@ -142,6 +142,7 @@ let lookup_glue name t =
 
 let zone name t =
   match lookup_aux name t with
+  | Error (`NotFound (zone, soa)) -> Ok (zone, soa)
   | Error e -> Error e
   | Ok (zone, _, _) ->
     match check_zone zone with


### PR DESCRIPTION
Dns_mirage_server.primary: include above key name and source IP in on_update

this is mostly useful for a primary server with a git backend to create sensible commit messages

/cc @cfcs