### PR TITLE
Remove unused dune extension

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,2 @@
 (lang dune 1.2)
 (name dns)
-(using menhir 2.0)


### PR DESCRIPTION
The `menhir 2.0` extension for dune was introduced in dune 1.4 (see https://github.com/ocaml/dune/pull/863). Trying to use dune 1.2 or 1.3 on this project will result in an error.

This PR readjusts the constraints on dune to avoid such problem.

(discussed in https://github.com/ocaml/opam-repository/pull/15646)
(related to https://github.com/ocaml/dune/issues/2957)