### PR TITLE
server bugfix (in update); metrics

### DIFF
--- a/server/dns_server.mli
+++ b/server/dns_server.mli
@@ -8,7 +8,8 @@ open Dns
 module Authentication : sig
   (** A key is a pair of a [`raw Domain_name.t] and a [Dnskey.t]. In the name,
       operation privileges and potentially IP addresses are encoded, e.g.
-      [foo._transfer.example.com] may do AXFR on [example.com]. *)
+      [foo._transfer.example.com] may do AXFR on [example.com] and any
+      subdomain, e.g. [foo.example.com]. *)
 
   type operation = [
     | `Update
@@ -19,13 +20,23 @@ module Authentication : sig
       [`Update] may as well carry out a [`Transfer]. *)
 
   val all_ops : operation list
+  (** [all_ops] is a list of all operations. *)
 
-  type t
-  (** The type for an authenticator. *)
+  val access_granted : required:operation -> operation -> bool
+  (** [access_granted ~required key_operation] is [true] if [key_operation] is
+      authorised for [required] operation. *)
+
+  val zone_and_operation : 'a Domain_name.t -> ([`host] Domain_name.t * operation) option
+  (** [zone_and_operation key] is [Some (zone, op)], the [zone] of the [key],
+      and its operation [op]. If the [key] is not in the expected format, [None]
+      is returned. *)
 
   val access : ?key:'a Domain_name.t -> zone:'b Domain_name.t -> operation -> bool
   (** [access op ~key ~zone] checks whether [key] is authorised for [op] on
       [zone]. *)
+
+  type t
+  (** Opaque type for storing authentication keys. *)
 end
 
 type t = private {

--- a/server/dns_server.mli
+++ b/server/dns_server.mli
@@ -74,6 +74,9 @@ val handle_axfr_request : t -> proto -> [ `raw ] Domain_name.t option ->
     transfer request and processes it. If the request is valid, and the zone
     available, a zone transfer is returned. *)
 
+val counter_metrics : f:('a -> string) ->
+  string -> (Metrics.field list, 'a -> Metrics.Data.t) Metrics.src
+
 type trie_cache
 
 val handle_ixfr_request : t -> trie_cache -> proto -> [ `raw ] Domain_name.t option ->

--- a/server/dune
+++ b/server/dune
@@ -2,4 +2,4 @@
  (name dns_server)
  (public_name dns-server)
  (wrapped false)
- (libraries dns randomconv duration))
+ (libraries dns randomconv duration metrics))

--- a/src/dns.mli
+++ b/src/dns.mli
@@ -144,6 +144,9 @@ module Rcode : sig
   val compare : t -> t -> int
   (** [compare a b] compares the response code [a] with [b] using the
       RFC-specified integer representation of response codes. *)
+
+  val to_string : t -> string
+  (** [to_string t] is a string representation of [t]. *)
 end
 
 (** Start of authority


### PR DESCRIPTION
this adds more tests, esp. for the case a server has multiple zones and only one is updated. in 4.3.0 this lead to SOA serial bumps of all zones the primary is serving.

another test is a single nsupdate which updates multiple zones at once.

in dns server, also expose some counter metrics about received and transmitted dns packets