### PR TITLE
cache: clip ttl to hour..ttl..week

### DIFF
--- a/cache/dns_cache.ml
+++ b/cache/dns_cache.ml
@@ -211,15 +211,21 @@ and 1035 6.2:
    maximum value! *)
 let week = Int32.of_int Duration.(to_sec (of_day 7))
 
-let clip_ttl_to_week entry =
+let min_ttl = Int32.of_int (Duration.(to_sec (of_hour 1)))
+
+let clip_ttl_to_min_hour_max_week entry =
   let ttl = get_ttl entry in
-  if ttl < week then entry else with_ttl week entry
+  if ttl < min_ttl
+  then with_ttl min_ttl entry
+  else if ttl >= week
+  then with_ttl week entry
+  else entry
 
 let pp_query ppf (name, query_type) =
   Fmt.pf ppf "%a (%a)" Domain_name.pp name Packet.Question.pp_qtype query_type
 
 let set cache ts name query_type rank entry  =
-  let entry' = clip_ttl_to_week entry in
+  let entry' = clip_ttl_to_min_hour_max_week entry in
   let cache' map = insert cache ?map ts name query_type rank entry' in
   match find cache name query_type with
   | map, Error _ ->


### PR DESCRIPTION
this is likely controversial -- reasoning behind this is https://00f.net/2019/11/03/stop-using-low-dns-ttls/ and the observation that e.g. github.com has ridiciously low ttls for no good reason... this PR is mostly a reminder that the current behaviour is not optimal for most setups, and should be refined. an option could be to provide configuration arguments (though dns cache doesn't have configuration atm); or we decide to merge and use the increased lower ttl. i tried this at the reproducible builds summit in december 2019 in marrakesh and didn't hear any complaints -- i suspect nobody noticed...