### PR TITLE
Find secondaries

### DIFF
--- a/server/dns_server.ml
+++ b/server/dns_server.ml
@@ -466,10 +466,9 @@ module Notification = struct
         | Error _ -> ns
         | Ok prim -> Domain_name.Host_set.remove prim ns
       in
-      (* TODO AAAA records / use lookup_glue? *)
       Domain_name.Host_set.fold (fun ns acc ->
-          match Dns_trie.lookup ns Rr_map.A trie with
-          | Ok (_, ips) -> Rr_map.Ipv4_set.union ips acc
+          match Dns_trie.lookup_glue ns trie with
+          | Some (_, ips), _ -> Rr_map.Ipv4_set.union ips acc
           | _ ->
             Log.err (fun m -> m "lookup for A %a returned nothing as well"
                         Domain_name.pp ns);

--- a/server/dns_server.ml
+++ b/server/dns_server.ml
@@ -470,8 +470,8 @@ module Notification = struct
           match Dns_trie.lookup_glue ns trie with
           | Some (_, ips), _ -> Rr_map.Ipv4_set.union ips acc
           | _ ->
-            Log.err (fun m -> m "lookup for A %a returned nothing as well"
-                        Domain_name.pp ns);
+            Log.warn (fun m -> m "could not find an address record for the secondary %a (zone %a), it won't be notified"
+                         Domain_name.pp ns Domain_name.pp zone);
             acc)
         secondaries Rr_map.Ipv4_set.empty
     | _ -> Rr_map.Ipv4_set.empty

--- a/server/dns_server.ml
+++ b/server/dns_server.ml
@@ -466,6 +466,7 @@ module Notification = struct
         | Error _ -> ns
         | Ok prim -> Domain_name.Host_set.remove prim ns
       in
+      (* TODO AAAA records *)
       Domain_name.Host_set.fold (fun ns acc ->
           match Dns_trie.lookup_glue ns trie with
           | Some (_, ips), _ -> Rr_map.Ipv4_set.union ips acc

--- a/server/dns_trie.ml
+++ b/server/dns_trie.ml
@@ -120,13 +120,12 @@ let lookup_with_cname name ty t =
 let lookup name key t =
   match lookup_aux name t with
   | Error e -> Error e
-  | Ok (zone, _sub, map) ->
-    match Rr_map.find key map with
-    | Some v -> Ok v
-    | None -> match zone with
-      | None -> Error `NotAuthoritative
-      | Some (`Delegation (name, (ttl, ns))) -> Error (`Delegation (name, (ttl, ns)))
-      | Some (`Soa (z, zmap)) -> Error (ent z zmap)
+  | Ok (None, _sub, _map) -> Error `NotAuthoritative
+  | Ok (Some zone, _sub, map) ->
+    match Rr_map.find key map, zone with
+    | Some v, _ -> Ok v
+    | None, `Delegation (name, (ttl, ns)) -> Error (`Delegation (name, (ttl, ns)))
+    | None, `Soa (z, zmap) -> Error (ent z zmap)
 
 let lookup_any name t =
   match lookup_aux name t with

--- a/test/server.ml
+++ b/test/server.ml
@@ -31,6 +31,31 @@ module Trie = struct
     end in
     (module M: Alcotest.TESTABLE with type t = M.t)
 
+  let glue_ok =
+    let module M = struct
+      type t = (int32 * Rr_map.Ipv4_set.t) option * (int32 * Rr_map.Ipv6_set.t) option
+      let pp ppf (v4, v6) =
+        let pp_v4 ppf v4 =
+          Fmt.(list ~sep:(unit ",") Ipaddr.V4.pp) ppf (Rr_map.Ipv4_set.elements v4)
+        and pp_v6 ppf v6 =
+          Fmt.(list ~sep:(unit ",") Ipaddr.V6.pp) ppf (Rr_map.Ipv6_set.elements v6)
+        in
+        Fmt.pf ppf "V4 %a@ V6 %a"
+          Fmt.(option ~none:(unit "none") (pair ~sep:(unit ", ") int32 pp_v4)) v4
+          Fmt.(option ~none:(unit "none") (pair ~sep:(unit ", ") int32 pp_v6)) v6
+      let equal a b = match a, b with
+        | (None, None), (None, None) -> true
+        | (Some (ttl, v4), None), (Some (ttl', v4'), None) ->
+          ttl = ttl' && Rr_map.Ipv4_set.equal v4 v4'
+        | (None, Some (ttl, v6)), (None, Some (ttl', v6')) ->
+          ttl = ttl' && Rr_map.Ipv6_set.equal v6 v6'
+        | (Some (ttl, v4), Some (ttl6, v6)), (Some (ttl', v4'), Some (ttl6', v6')) ->
+          ttl = ttl' && Rr_map.Ipv4_set.equal v4 v4' &&
+            ttl6 = ttl6' && Rr_map.Ipv6_set.equal v6 v6'
+        | _ -> false
+    end in
+    (module M: Alcotest.TESTABLE with type t = M.t)
+
   let l_ok =
     let module M = struct
       type t = Rr_map.b * ([ `raw ] Domain_name.t * int32 * Domain_name.Host_set.t)
@@ -402,6 +427,25 @@ module Trie = struct
                 (Error `NotAuthoritative)
                 (zone (n_of_s "bar.com") t))
 
+  let no_soa () =
+    let a_record = (23l, Rr_map.Ipv4_set.singleton (ip "1.4.5.2")) in
+    let t = insert (n_of_s "ns1.foo.com") Rr_map.A a_record empty in
+    Alcotest.(check (result b_ok e) "lookup_with_cname for NS foo.com without SOA fails"
+                (Error `NotAuthoritative)
+                (r_fst (lookup_with_cname (n_of_s "foo.com") Ns t))) ;
+    Alcotest.(check (result b_ok e) "lookup_with_cname for A ns1.foo.com without SOA fails"
+                (Error `NotAuthoritative)
+                (r_fst (lookup_with_cname (n_of_s "ns1.foo.com") A t))) ;
+    Alcotest.(check (result b_ok e) "lookup_b for NS foo.com without SOA fails"
+                (Error `NotAuthoritative)
+                (lookup_b (n_of_s "foo.com") Ns t)) ;
+    Alcotest.(check (result b_ok e) "lookup_b for A ns1.foo.com without SOA fails"
+                (Error `NotAuthoritative)
+                (lookup_b (n_of_s "ns1.foo.com") A t)) ;
+    Alcotest.(check glue_ok "lookup_glue for ns1.foo.com without SOA finds ip"
+                (Some a_record, None)
+                (Dns_trie.lookup_glue (n_of_s "ns1.foo.com") t))
+
   let tests = [
     "simple", `Quick, simple ;
     "basic", `Quick, basic ;
@@ -409,6 +453,7 @@ module Trie = struct
     "delegation", `Quick, dele ;
     "rmzone", `Quick, rmzone ;
     "zone", `Quick, zone ;
+    "no soa", `Quick, no_soa ;
   ]
 end
 


### PR DESCRIPTION
this strengthens the `lookup` function (to return `` `NotAuthoritative`` more often), and relaxes the `Notification.secondaries` to also find glue records in the trie. This addresses (with some further changes to the primary-git unikernel #213)

also add tests for lookup in a trie where the zone does not contain a SOA record (glue-only), `lookup_glue` returns the resource record set

//cc @cfcs @dinosaure 