### PR TITLE
dns: provide Dnskey.pp_name_key (best used with Cmdliner)

### DIFF
--- a/src/dns.ml
+++ b/src/dns.ml
@@ -754,6 +754,9 @@ module Dnskey = struct
       Domain_name.of_string name >>= fun name ->
       of_string key >>| fun dnskey ->
       (name, dnskey)
+
+  let pp_name_key ppf (name, key) =
+    Fmt.pf ppf "%a %a" Domain_name.pp name pp key
 end
 
 (* certificate authority authorization *)

--- a/src/dns.mli
+++ b/src/dns.mli
@@ -341,6 +341,9 @@ module Dnskey : sig
   val name_key_of_string : string -> ([ `raw ] Domain_name.t * t, [> `Msg of string ]) result
   (** [name_key_of_string str] attempts to parse [str] to a domain name and a
       dnskey. The colon character ([:]) is used as separator. *)
+
+  val pp_name_key : ([ `raw ] Domain_name.t * t) Fmt.t
+  (** [pp_name_key (name, key)] pretty-prints the dnskey and name pair. *)
 end
 
 (** Certificate authority authorization


### PR DESCRIPTION
The argument processing of [cmdliner](https://erratique.ch/software/cmdliner/doc/Cmdliner.Arg.html#VALconv) works with a parser (``string -> ('a, [ `Msg of string ]) result``) and a pretty-printer (`'a Fmt.t`). Now, Dnskey.name_key_of_string provides the latter (and is used by a bunch of unikernels), while there's no `pp` for that pair. For convenience, the pretty-printer should be included. (see e.g. https://github.com/mmaker/ocaml-letsencrypt/blob/bfe9982cb21f56cbe3b13f9f5291d0ba37daf7d9/bin/oacmel.ml#L103-L109 or https://github.com/roburio/unikernels/blob/5ef50400420e66e9cfb7f96ec7c6258e0944328b/secondary/config.ml#L5-L7 (further processed in https://github.com/roburio/unikernels/blob/5ef50400420e66e9cfb7f96ec7c6258e0944328b/secondary/unikernel.ml#L6-L11)) where this may be useful.