### PR TITLE
add timeout for dns-client

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+### v4.5.0 (2020-04-23)
+
+* client: add timeout for DNS requests (defaults to 5 seconds, as in resolv.h).
+* dns-client-mirage functor requires a Mirage_time.S implementation (changes API).
+  Update your code as in this commit:
+  https://github.com/roburio/unikernels/commit/201e980f458ebb515298392227294e7b508a1009
+  #223 @linse @hannesm, review by @cfcs
+
 ### v4.4.1 (2020-03-29)
 
 * client: treat '*.localhost' and '*.invalid' special, as specified in RFC 6761

--- a/app/odns.ml
+++ b/app/odns.ml
@@ -33,9 +33,8 @@ let ns ip is_udp = match ip with
   | Some ip -> if is_udp then Some (`UDP, ip) else Some (`TCP, ip)
 
 let do_a nameserver is_udp domains _ =
-  let clock = Mtime_clock.elapsed_ns in
   let nameserver = ns nameserver is_udp in
-  let t = Dns_client_lwt.create ?nameserver ~clock () in
+  let t = Dns_client_lwt.create ?nameserver () in
   let (_, (ns_ip, _)) = Dns_client_lwt.nameserver t in
   Logs.info (fun m -> m "querying NS %s for A records of %a"
                 (Unix.string_of_inet_addr ns_ip)
@@ -65,9 +64,8 @@ let for_all_domains nameserver is_udp ~domains typ f =
   (* [for_all_domains] is a utility function that lets us avoid duplicating
      this block of code in all the subcommands.
      We leave {!do_a} simple to provide a more readable example. *)
-  let clock = Mtime_clock.elapsed_ns in
   let nameserver = ns nameserver is_udp in
-  let t = Dns_client_lwt.create ?nameserver ~clock () in
+  let t = Dns_client_lwt.create ?nameserver () in
   let _, (ns_ip, _) = Dns_client_lwt.nameserver t in
   Logs.info (fun m -> m "NS: %s" @@ Unix.string_of_inet_addr ns_ip);
   let open Lwt in

--- a/app/odns.ml
+++ b/app/odns.ml
@@ -28,8 +28,13 @@ let pp_zone_tlsa ppf (domain,ttl,(tlsa:Dns.Tlsa.t)) =
         | n -> loop ((String.sub hex n 56)::acc) (n+56)
       in loop [] 0)
 
-let do_a nameserver domains _ =
+let ns ip is_udp = match ip with
+  | None -> None
+  | Some ip -> if is_udp then Some (`UDP, ip) else Some (`TCP, ip)
+
+let do_a nameserver is_udp domains _ =
   let clock = Mtime_clock.elapsed_ns in
+  let nameserver = ns nameserver is_udp in
   let t = Dns_client_lwt.create ?nameserver ~clock () in
   let (_, (ns_ip, _)) = Dns_client_lwt.nameserver t in
   Logs.info (fun m -> m "querying NS %s for A records of %a"
@@ -56,11 +61,12 @@ let do_a nameserver domains _ =
   match Lwt_main.run job with
   | () -> Ok () (* TODO handle errors *)
 
-let for_all_domains nameserver ~domains typ f =
+let for_all_domains nameserver is_udp ~domains typ f =
   (* [for_all_domains] is a utility function that lets us avoid duplicating
      this block of code in all the subcommands.
      We leave {!do_a} simple to provide a more readable example. *)
   let clock = Mtime_clock.elapsed_ns in
+  let nameserver = ns nameserver is_udp in
   let t = Dns_client_lwt.create ?nameserver ~clock () in
   let _, (ns_ip, _) = Dns_client_lwt.nameserver t in
   Logs.info (fun m -> m "NS: %s" @@ Unix.string_of_inet_addr ns_ip);
@@ -84,16 +90,16 @@ let pp_response typ domain = function
   | Error _ -> ()
   | Ok resp -> Logs.app (fun m -> m "%a" pp_zone (domain, typ, resp))
 
-let do_aaaa nameserver domains _ =
-  for_all_domains nameserver ~domains Dns.Rr_map.Aaaa
+let do_aaaa nameserver is_udp domains _ =
+  for_all_domains nameserver is_udp ~domains Dns.Rr_map.Aaaa
     (pp_response Dns.Rr_map.Aaaa)
 
-let do_mx nameserver domains _ =
-  for_all_domains nameserver ~domains Dns.Rr_map.Mx
+let do_mx nameserver is_udp domains _ =
+  for_all_domains nameserver is_udp ~domains Dns.Rr_map.Mx
     (pp_response Dns.Rr_map.Mx)
 
-let do_tlsa nameserver domains _ =
-  for_all_domains nameserver ~domains Dns.Rr_map.Tlsa
+let do_tlsa nameserver is_udp domains _ =
+  for_all_domains nameserver is_udp ~domains Dns.Rr_map.Tlsa
     (fun domain -> function
        | Ok (ttl, tlsa_resp) ->
          Dns.Rr_map.Tlsa_set.iter (fun tlsa ->
@@ -102,8 +108,8 @@ let do_tlsa nameserver domains _ =
        | Error _ -> () )
 
 
-let do_txt nameserver domains _ =
-  for_all_domains nameserver ~domains Dns.Rr_map.Txt
+let do_txt nameserver is_udp domains _ =
+  for_all_domains nameserver is_udp ~domains Dns.Rr_map.Txt
     (fun _domain -> function
        | Ok (ttl, txtset) ->
          Dns.Rr_map.Txt_set.iter (fun txtrr ->
@@ -112,17 +118,17 @@ let do_txt nameserver domains _ =
        | Error _ -> () )
 
 
-let do_any _nameserver _domains _ =
+let do_any _nameserver _is_udp _domains _ =
   (* TODO *)
   Error (`Msg "ANY functionality is not present atm due to refactorings, come back later")
 
-let do_dkim nameserver (selector:string) domains _ =
+let do_dkim nameserver is_udp (selector:string) domains _ =
   let domains = List.map (fun original_domain ->
       Domain_name.prepend_label_exn
         (Domain_name.prepend_label_exn
            (original_domain) "_domainkey") selector
     ) domains in
-  for_all_domains nameserver ~domains Dns.Rr_map.Txt
+  for_all_domains nameserver is_udp ~domains Dns.Rr_map.Txt
     (fun _domain -> function
        | Ok (_ttl, txtset) ->
          Dns.Rr_map.Txt_set.iter (fun txt ->
@@ -144,17 +150,24 @@ let setup_log =
   Term.(const _setup_log $ Fmt_cli.style_renderer ~docs:sdocs ()
         $ Logs_cli.level ~docs:sdocs ())
 
-let parse_ns : ('a * (Lwt_unix.inet_addr * int)) Arg.conv =
+let parse_ns : (Lwt_unix.inet_addr * int) Arg.conv =
   ( fun ns ->
-      try `Ok (`TCP, (Unix.inet_addr_of_string ns, 53)) with
+      try match String.split_on_char ':' ns with
+      | [ ns ] -> `Ok (Unix.inet_addr_of_string ns, 53)
+      | [ ns ; port ] -> `Ok (Unix.inet_addr_of_string ns, int_of_string port)
+      | _ -> `Error "bad name server"
+      with
       | _ -> `Error "NS must be an IPv4 address"),
-  ( fun ppf (typ, (ns, port)) ->
-      Fmt.pf ppf "%s:%d(%s)" (Unix.string_of_inet_addr ns) port
-        (match typ with `UDP -> "udp" | `TCP -> "tcp"))
+  ( fun ppf (ns, port) ->
+      Fmt.pf ppf "%s:%d" (Unix.string_of_inet_addr ns) port )
 
 let arg_ns : 'a Term.t =
   let doc = "IP of nameserver to use" in
   Arg.(value & opt (some parse_ns) None & info ~docv:"NS-IP" ~doc ["ns"])
+
+let arg_udp =
+  let doc = "Connect via UDP to resolver" in
+  Arg.(value & flag & info [ "udp" ] ~doc)
 
 let parse_domain : [ `raw ] Domain_name.t Arg.conv =
   ( fun name ->
@@ -179,7 +192,7 @@ let cmd_a : unit Term.t * Term.info =
   let man = [
     `P {| Output mimics that of $(b,dig A )$(i,DOMAIN)|}
   ] in
-  Term.(term_result (const do_a $ arg_ns $ arg_domains $ setup_log)),
+  Term.(term_result (const do_a $ arg_ns $ arg_udp $ arg_domains $ setup_log)),
   Term.info "a" ~version:(Manpage.escape "%%VERSION%%") ~man ~doc ~sdocs
 
 let cmd_aaaa : unit Term.t * Term.info =
@@ -187,7 +200,7 @@ let cmd_aaaa : unit Term.t * Term.info =
   let man = [
     `P {| Output mimics that of $(b,dig AAAA )$(i,DOMAIN)|}
   ] in
-  Term.(term_result (const do_aaaa $ arg_ns $ arg_domains $ setup_log)),
+  Term.(term_result (const do_aaaa $ arg_ns $ arg_udp $ arg_domains $ setup_log)),
   Term.info "aaaa" ~version:(Manpage.escape "%%VERSION%%") ~man ~doc ~sdocs
 
 let cmd_mx : unit Term.t * Term.info =
@@ -195,7 +208,7 @@ let cmd_mx : unit Term.t * Term.info =
   let man = [
     `P {| Output mimics that of $(b,dig MX )$(i,DOMAIN)|}
   ] in
-  Term.(term_result (const do_mx $ arg_ns $ arg_domains $ setup_log)),
+  Term.(term_result (const do_mx $ arg_ns $ arg_udp $ arg_domains $ setup_log)),
   Term.info "mx" ~version:(Manpage.escape "%%VERSION%%") ~man ~doc ~sdocs
 
 let cmd_tlsa : unit Term.t * Term.info =
@@ -217,7 +230,7 @@ let cmd_tlsa : unit Term.t * Term.info =
     `P {| $(b,_993._tcp) (IMAP) |} ;
     `S Manpage.s_options ;
   ] in
-  Term.(term_result (const do_tlsa $ arg_ns $ arg_domains $ setup_log)),
+  Term.(term_result (const do_tlsa $ arg_ns $ arg_udp $ arg_domains $ setup_log)),
   Term.info "tlsa" ~version:(Manpage.escape "%%VERSION%%") ~man ~doc ~sdocs
 
 let cmd_txt : unit Term.t * Term.info =
@@ -229,7 +242,7 @@ let cmd_txt : unit Term.t * Term.info =
           It would be nice to mirror `dig` output here.|} ;
     `S Manpage.s_options ;
   ] in
-  Term.(term_result (const do_txt $ arg_ns $ arg_domains $ setup_log)),
+  Term.(term_result (const do_txt $ arg_ns $ arg_udp $ arg_domains $ setup_log)),
   Term.info "txt" ~version:(Manpage.escape "%%VERSION%%") ~man ~doc ~sdocs
 
 let cmd_any : unit Term.t * Term.info =
@@ -240,7 +253,7 @@ let cmd_any : unit Term.t * Term.info =
     `P {| The output will be fairly similar to $(b,dig ANY )$(i,example.com)|} ;
     `S Manpage.s_options ;
   ] in
-  Term.(term_result (const do_any $ arg_ns $ arg_domains $ setup_log)),
+  Term.(term_result (const do_any $ arg_ns $ arg_udp $ arg_domains $ setup_log)),
   Term.info "any" ~version:(Manpage.escape "%%VERSION%%") ~man ~doc ~sdocs
 
 let cmd_dkim : unit Term.t * Term.info =
@@ -256,7 +269,7 @@ let cmd_dkim : unit Term.t * Term.info =
        |} ;
     `S Manpage.s_options ;
   ] in
-  Term.(term_result (const do_dkim $ arg_ns $ arg_selector
+  Term.(term_result (const do_dkim $ arg_ns $ arg_udp $ arg_selector
                      $ arg_domains $ setup_log)),
   Term.info "dkim" ~version:(Manpage.escape "%%VERSION%%") ~man ~doc ~sdocs
 

--- a/dns-client.opam
+++ b/dns-client.opam
@@ -25,8 +25,10 @@ depends: [
   "lwt" {>= "4.2.1"}
   "mirage-stack" {>= "2.0.0"}
   "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
+  "mirage-crypto-rng"
 ]
 synopsis: "Pure DNS resolver API"
 description: """

--- a/lwt/client/dns_client_lwt.mli
+++ b/lwt/client/dns_client_lwt.mli
@@ -1,13 +1,18 @@
 (** {!Lwt_unix} helper module for {!Dns_client}.
     For more information see the {!Dns_client.Make} functor.
+
+    The {!Dns_client} is available as Dns_client_lwt after
+    linking to dns-client.lwt in your dune file.
+
+    The [create] function embeds the side effect of initializing the RNG
+    by calling {!Mirage_crypto_rng_unix.initialize}.
 *)
 
 
 (** A flow module based on non-blocking I/O on top of the
     Lwt_unix socket API. *)
 module Transport : Dns_client.S
-  with type flow = Lwt_unix.file_descr
-   and type io_addr = Lwt_unix.inet_addr * int
+   with type io_addr = Lwt_unix.inet_addr * int
    and type +'a io = 'a Lwt.t
    and type stack = unit
 

--- a/lwt/client/dune
+++ b/lwt/client/dune
@@ -2,5 +2,5 @@
   (name        dns_client_lwt)
   (modules     dns_client_lwt)
   (public_name dns-client.lwt)
-  (libraries   lwt lwt.unix dns dns-client)
+  (libraries   lwt lwt.unix dns dns-client mtime.clock.os mirage-crypto-rng.unix)
   (wrapped     false))

--- a/mirage/client/dns_client_mirage.ml
+++ b/mirage/client/dns_client_mirage.ml
@@ -3,64 +3,69 @@ open Lwt.Infix
 let src = Logs.Src.create "dns_client_mirage" ~doc:"effectful DNS client layer"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-module Make (R : Mirage_random.S) (C : Mirage_clock.MCLOCK) (S : Mirage_stack.V4) = struct
+module Make (R : Mirage_random.S) (T : Mirage_time.S) (C : Mirage_clock.MCLOCK) (S : Mirage_stack.V4) = struct
 
   module Transport : Dns_client.S
-    with type flow = S.TCPV4.flow
-     and type stack = S.t
+    with type stack = S.t
      and type +'a io = 'a Lwt.t
      and type io_addr = Ipaddr.V4.t * int = struct
-    type flow = S.TCPV4.flow
     type stack = S.t
     type io_addr = Ipaddr.V4.t * int
     type ns_addr = [`TCP | `UDP] * io_addr
     type +'a io = 'a Lwt.t
     type t = {
-      rng : (int -> Cstruct.t) ;
       nameserver : ns_addr ;
+      timeout_ns : int64 ;
       stack : stack ;
     }
+    type context = { t : t ; flow : S.TCPV4.flow ; timeout_ns : int64 ref }
 
     let create
-        ?rng
         ?(nameserver = `TCP, (Ipaddr.V4.of_string_exn Dns_client.default_resolver, 53))
+        ~timeout
         stack =
-      let rng = match rng with None -> R.generate ?g:None | Some x -> x in
-      { rng ; nameserver ; stack }
+      { nameserver ; timeout_ns = timeout ; stack }
 
     let nameserver { nameserver ; _ } = nameserver
-    let rng { rng ; _ } = rng
+    let rng = R.generate ?g:None
+    let clock = C.elapsed_ns
+
+    let with_timeout time_left f =
+      let timeout = T.sleep_ns !time_left >|= fun () -> Error (`Msg "DNS request timeout") in
+      let start = clock () in
+      Lwt.pick [ f ; timeout ] >|= fun result ->
+      let stop = clock () in
+      time_left := Int64.sub !time_left (Int64.sub stop start);
+      result
 
     let bind = Lwt.bind
     let lift = Lwt.return
 
     let connect ?nameserver:ns t =
       let _proto, addr = match ns with None -> nameserver t | Some x -> x in
-      S.TCPV4.create_connection (S.tcpv4 t.stack) addr >|= function
+      let time_left = ref t.timeout_ns in
+      with_timeout time_left (S.TCPV4.create_connection (S.tcpv4 t.stack) addr >|= function
       | Error e ->
         Log.err (fun m -> m "error connecting to nameserver %a"
                     S.TCPV4.pp_error e) ;
         Error (`Msg "connect failure")
-      | Ok flow -> Ok flow
+      | Ok flow -> Ok { t ; flow ; timeout_ns = time_left })
 
-    let close f = S.TCPV4.close f
+    let close { flow ; _ } = S.TCPV4.close flow
 
-    let recv flow =
-      S.TCPV4.read flow >|= function
+    let recv ctx =
+      with_timeout ctx.timeout_ns (S.TCPV4.read ctx.flow >|= function
       | Error e -> Error (`Msg (Fmt.to_to_string S.TCPV4.pp_error e))
       | Ok (`Data cs) -> Ok cs
-      | Ok `Eof -> Ok Cstruct.empty
+      | Ok `Eof -> Ok Cstruct.empty)
 
-    let send flow s =
-      S.TCPV4.write flow s >|= function
+    let send ctx s =
+      with_timeout ctx.timeout_ns (S.TCPV4.write ctx.flow s >|= function
       | Error e -> Error (`Msg (Fmt.to_to_string S.TCPV4.pp_write_error e))
-      | Ok () -> Ok ()
+      | Ok () -> Ok ())
   end
 
   include Dns_client.Make(Transport)
-
-  let create ?size ?nameserver stack =
-    create ?size ~rng:R.generate ?nameserver ~clock:C.elapsed_ns stack
 end
 
 (*

--- a/mirage/client/dns_client_mirage.mli
+++ b/mirage/client/dns_client_mirage.mli
@@ -1,17 +1,16 @@
 
-module Make (R : Mirage_random.S) (C : Mirage_clock.MCLOCK) (S : Mirage_stack.V4) : sig
+module Make (R : Mirage_random.S) (T : Mirage_time.S) (C : Mirage_clock.MCLOCK) (S : Mirage_stack.V4) : sig
   module Transport : Dns_client.S
-    with type flow = S.TCPV4.flow
-     and type io_addr = Ipaddr.V4.t * int
+    with type io_addr = Ipaddr.V4.t * int
      and type +'a io = 'a Lwt.t
      and type stack = S.t
 
   include module type of Dns_client.Make(Transport)
 
-  val create : ?size:int -> ?nameserver:Transport.ns_addr -> S.t -> t
+  val create : ?size:int -> ?nameserver:Transport.ns_addr -> ?timeout:int64 -> S.t -> t
   (** [create ~size ~nameserver stack] uses [R.generate] and [C.elapsed_ns] as
       random number generator and timestamp source, and calls the generic
-      [Dns_client.Make.create]. *)
+      {!Dns_client.Make.create}. *)
 end
 
 (*

--- a/mirage/client/dune
+++ b/mirage/client/dune
@@ -1,5 +1,5 @@
 (library
   (name        dns_client_mirage)
   (public_name dns-client.mirage)
-  (libraries   domain-name ipaddr mirage-random mirage-stack mirage-clock dns-client)
+  (libraries   domain-name ipaddr mirage-random mirage-time mirage-stack mirage-clock dns-client)
   (wrapped     false))

--- a/unix/client/dns_client_unix.mli
+++ b/unix/client/dns_client_unix.mli
@@ -3,10 +3,12 @@
 *)
 
 
-(** A flow module based on blocking I/O on top of the Unix socket API. *)
+(** A flow module based on blocking I/O on top of the Unix socket API.
+
+    TODO: Implement the connect timeout.
+*)
 module Transport : Dns_client.S
-  with type flow = Unix.file_descr
-   and type io_addr = Unix.inet_addr * int
+  with type io_addr = Unix.inet_addr * int
    and type stack = unit
    and type +'a io = 'a
 

--- a/unix/client/dune
+++ b/unix/client/dune
@@ -2,7 +2,7 @@
   (name        dns_client_unix)
   (modules     dns_client_unix)
   (public_name dns-client.unix)
-  (libraries   domain-name ipaddr dns-client rresult unix)
+  (libraries   domain-name ipaddr dns-client rresult unix mtime.clock.os mirage-crypto-rng.unix)
   (wrapped     false))
 
 (executable

--- a/unix/client/ohost.ml
+++ b/unix/client/ohost.ml
@@ -1,6 +1,5 @@
 let () =
-  let clock = Mtime_clock.elapsed_ns in
-  let t = Dns_client_unix.create ~clock () in
+  let t = Dns_client_unix.create () in
   let domain = Domain_name.(host_exn (of_string_exn Sys.argv.(1))) in
   let ipv4 =
     match Dns_client_unix.gethostbyname t domain with


### PR DESCRIPTION
our goal was to have connect and request timeouts for the DNS client.

On the Unix backend, we only have request timeouts (since there's no socket option to set connect timeouts, and we didn't want to use `select`).

On Lwt, we can't use the `SO_RCVTIMEO` socket option since it results in EAGAIN which is handled by Lwt (which re-queues the event). Thus we use a Lwt.pick there (same on MirageOS).