### PR TITLE
client: avoid initialization of RNG in library, move to appplications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,14 @@ env:
   global:
     - PINS="dns.dev:. dns-certify.dev:. dns-client.dev:. dns-resolver.dev:. dns-server.dev:. dns-tsig.dev:. dns-cli.dev:. dns-mirage.dev:. dns-stub.dev:."
   matrix:
-    - DISTRO=alpine OCAML_VERSION=4.07 PACKAGE="dns"
-    - DISTRO=alpine OCAML_VERSION=4.07 PACKAGE="dns-resolver"
-    - DISTRO=alpine OCAML_VERSION=4.07 PACKAGE="dns-mirage"
-    - DISTRO=alpine OCAML_VERSION=4.07 PACKAGE="dns-certify"
-    - DISTRO=alpine OCAML_VERSION=4.07 PACKAGE="dns-client"
-    - DISTRO=alpine OCAML_VERSION=4.07 PACKAGE="dns-server"
-    - DISTRO=alpine OCAML_VERSION=4.07 PACKAGE="dns-tsig"
-    - DISTRO=alpine OCAML_VERSION=4.07 PACKAGE="dns-cli"
-    - DISTRO=alpine OCAML_VERSION=4.07 PACKAGE="dns-stub"
+    - DISTRO=alpine OCAML_VERSION=4.10 PACKAGE="dns"
+    - DISTRO=alpine OCAML_VERSION=4.10 PACKAGE="dns-resolver"
+    - DISTRO=alpine OCAML_VERSION=4.10 PACKAGE="dns-mirage"
+    - DISTRO=alpine OCAML_VERSION=4.10 PACKAGE="dns-certify"
+    - DISTRO=alpine OCAML_VERSION=4.10 PACKAGE="dns-client"
+    - DISTRO=alpine OCAML_VERSION=4.10 PACKAGE="dns-server"
+    - DISTRO=alpine OCAML_VERSION=4.10 PACKAGE="dns-tsig"
+    - DISTRO=alpine OCAML_VERSION=4.10 PACKAGE="dns-cli"
+    - DISTRO=alpine OCAML_VERSION=4.10 PACKAGE="dns-stub"
 notifications:
   email: false

--- a/app/dune
+++ b/app/dune
@@ -17,14 +17,14 @@
   (public_name oupdate)
   (package dns-cli)
   (modules oupdate)
-  (libraries dns dns-tsig dns-cli ptime ptime.clock.os mirage-crypto mirage-crypto-rng.unix))
+  (libraries dns dns-tsig dns-cli ptime ptime.clock.os mirage-crypto mirage-crypto-rng.unix randomconv))
 
 (executable
   (name onotify)
   (public_name onotify)
   (package dns-cli)
   (modules onotify)
-  (libraries dns dns-tsig dns-cli ptime ptime.clock.os mirage-crypto mirage-crypto-rng.unix))
+  (libraries dns dns-tsig dns-cli ptime ptime.clock.os mirage-crypto mirage-crypto-rng.unix randomconv))
 
 (executable
   (name ozone)
@@ -39,4 +39,4 @@
   (modules      odns)
   (package      dns-cli)
   (libraries    dns dns-client.lwt dns-cli cmdliner mtime.clock.os
-                lwt.unix hex rresult))
+                lwt.unix hex rresult mirage-crypto-rng.lwt))

--- a/app/onotify.ml
+++ b/app/onotify.ml
@@ -8,7 +8,7 @@ let notify zone serial key now =
   and soa =
     { Soa.nameserver = raw_zone ; hostmaster = raw_zone ; serial ;
       refresh = 0l; retry = 0l ; expiry = 0l ; minimum = 0l }
-  and header = Random.int 0xFFFF, Packet.Flags.singleton `Authoritative
+  and header = Randomconv.int16 Mirage_crypto_rng.generate, Packet.Flags.singleton `Authoritative
   in
   let p = Packet.create header question (`Notify (Some soa)) in
   match key with
@@ -20,7 +20,7 @@ let notify zone serial key now =
     | Error e -> Error e
 
 let jump _ serverip port zone key serial =
-  Random.self_init () ;
+  Mirage_crypto_rng_unix.initialize ();
   let now = Ptime_clock.now () in
   Logs.app (fun m -> m "notifying to %a:%d zone %a serial %lu"
                Ipaddr.V4.pp serverip port Domain_name.pp zone serial) ;

--- a/app/oupdate.ml
+++ b/app/oupdate.ml
@@ -13,12 +13,12 @@ let create_update zone hostname ip_address =
         ]
     in
     (Domain_name.Map.empty, up)
-  and header = Random.int 0xFFFF, Packet.Flags.empty
+  and header = Randomconv.int16 Mirage_crypto_rng.generate, Packet.Flags.empty
   in
   Packet.create header zone (`Update update)
 
 let jump _ serverip port (keyname, zone, dnskey) hostname ip_address =
-  Random.self_init () ;
+  Mirage_crypto_rng_unix.initialize ();
   let now = Ptime_clock.now () in
   Logs.app (fun m -> m "updating to %a:%d zone %a A 600 %a %a"
                Ipaddr.V4.pp serverip port

--- a/dns-cli.opam
+++ b/dns-cli.opam
@@ -9,7 +9,7 @@ license: "BSD2"
 
 depends: [
   "dune" {>= "1.2.0"}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.08.0"}
   "dns" {= version}
   "dns-tsig" {= version}
   "dns-client" {= version}
@@ -21,7 +21,7 @@ depends: [
   "fpath" {>= "0.7.2"}
   "x509" {>= "0.10.0"}
   "mirage-crypto"
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {>= "0.7.0"}
   "hex" {>= "1.4.0"}
   "ptime" {>= "0.8.5"}
   "mtime" {>= "1.2.0"}

--- a/lwt/client/dns_client_lwt.ml
+++ b/lwt/client/dns_client_lwt.ml
@@ -18,7 +18,6 @@ module Transport : Dns_client.S
   let create
     ?(nameserver = `TCP, (Unix.inet_addr_of_string Dns_client.default_resolver, 53))
     ~timeout () =
-    Mirage_crypto_rng_unix.initialize ();
     { nameserver ; timeout_ns = timeout }
 
   let nameserver { nameserver ; _ } = nameserver

--- a/lwt/client/dns_client_lwt.mli
+++ b/lwt/client/dns_client_lwt.mli
@@ -3,9 +3,6 @@
 
     The {!Dns_client} is available as Dns_client_lwt after
     linking to dns-client.lwt in your dune file.
-
-    The [create] function embeds the side effect of initializing the RNG
-    by calling {!Mirage_crypto_rng_unix.initialize}.
 *)
 
 

--- a/unix/client/dns_client_unix.ml
+++ b/unix/client/dns_client_unix.ml
@@ -20,7 +20,6 @@ module Transport : Dns_client.S
 
   let create
       ?(nameserver = `TCP, (Unix.inet_addr_of_string Dns_client.default_resolver, 53)) ~timeout () =
-    Mirage_crypto_rng_unix.initialize ();
     { nameserver ; timeout_ns = timeout }
 
   let nameserver { nameserver ; _ } = nameserver

--- a/unix/client/ohost.ml
+++ b/unix/client/ohost.ml
@@ -1,4 +1,5 @@
 let () =
+  Mirage_crypto_rng_unix.initialize ();
   let t = Dns_client_unix.create () in
   let domain = Domain_name.(host_exn (of_string_exn Sys.argv.(1))) in
   let ipv4 =


### PR DESCRIPTION
The application may use Lwt, which allows entropy collection