### PR TITLE
client: initialize RNG in library code

### DIFF
--- a/app/dune
+++ b/app/dune
@@ -17,14 +17,14 @@
   (public_name oupdate)
   (package dns-cli)
   (modules oupdate)
-  (libraries dns dns-tsig dns-cli ptime ptime.clock.os mirage-crypto mirage-crypto-rng.unix randomconv))
+  (libraries dns dns-tsig dns-cli ptime ptime.clock.os mirage-crypto-rng mirage-crypto-rng.unix randomconv))
 
 (executable
   (name onotify)
   (public_name onotify)
   (package dns-cli)
   (modules onotify)
-  (libraries dns dns-tsig dns-cli ptime ptime.clock.os mirage-crypto mirage-crypto-rng.unix randomconv))
+  (libraries dns dns-tsig dns-cli ptime ptime.clock.os mirage-crypto-rng mirage-crypto-rng.unix randomconv))
 
 (executable
   (name ozone)
@@ -39,4 +39,4 @@
   (modules      odns)
   (package      dns-cli)
   (libraries    dns dns-client.lwt dns-cli cmdliner mtime.clock.os
-                lwt.unix hex rresult mirage-crypto-rng.lwt))
+                lwt.unix hex rresult))

--- a/app/odns.ml
+++ b/app/odns.ml
@@ -3,8 +3,6 @@
 (* RFC 7766 DNS over TCP: https://tools.ietf.org/html/rfc7766 *)
 (* RFC 6698 DANE: https://tools.ietf.org/html/rfc6698*)
 
-open Lwt.Infix
-
 let pp_zone ppf (domain,query_type,query_value) =
   (* TODO dig also prints 'IN' after the TTL, we don't... *)
   Fmt.string ppf
@@ -42,7 +40,6 @@ let do_a nameserver is_udp domains _ =
                 (Unix.string_of_inet_addr ns_ip)
                 Fmt.(list ~sep:(unit", ") Domain_name.pp) domains);
   let job =
-    Mirage_crypto_rng_lwt.initialize () >>= fun () ->
     Lwt_list.iter_p (fun domain ->
         let open Lwt in
         Logs.debug (fun m -> m "looking up %a" Domain_name.pp domain);
@@ -73,8 +70,7 @@ let for_all_domains nameserver is_udp ~domains typ f =
   Logs.info (fun m -> m "NS: %s" @@ Unix.string_of_inet_addr ns_ip);
   let open Lwt in
   match Lwt_main.run
-          (Mirage_crypto_rng_lwt.initialize () >>= fun () ->
-           Lwt_list.iter_p
+          (Lwt_list.iter_p
              (fun domain ->
                 Dns_client_lwt.getaddrinfo t typ domain
                 >|= Rresult.R.reword_error

--- a/dns-client.opam
+++ b/dns-client.opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {>= "0.8.0"}
   "alcotest" {with-test}
 ]
 synopsis: "Pure DNS resolver API"

--- a/lwt/client/dns_client_lwt.ml
+++ b/lwt/client/dns_client_lwt.ml
@@ -96,3 +96,6 @@ end
 (* Now that we have our {!Transport} implementation we can include the logic
    that goes on top of it: *)
 include Dns_client.Make(Transport)
+
+(* initialize the RNG *)
+let () = Mirage_crypto_rng_lwt.initialize ()

--- a/lwt/client/dns_client_lwt.mli
+++ b/lwt/client/dns_client_lwt.mli
@@ -3,6 +3,8 @@
 
     The {!Dns_client} is available as Dns_client_lwt after
     linking to dns-client.lwt in your dune file.
+
+    It initializes the RNG (using Mirage_crypto_rng_lwt.initialize ()).
 *)
 
 

--- a/lwt/client/dune
+++ b/lwt/client/dune
@@ -2,5 +2,5 @@
   (name        dns_client_lwt)
   (modules     dns_client_lwt)
   (public_name dns-client.lwt)
-  (libraries   lwt lwt.unix dns dns-client mtime.clock.os mirage-crypto-rng.unix)
+  (libraries   lwt lwt.unix dns dns-client mtime.clock.os mirage-crypto-rng.lwt)
   (wrapped     false))

--- a/unix/client/dns_client_unix.ml
+++ b/unix/client/dns_client_unix.ml
@@ -98,3 +98,6 @@ end
 (* Now that we have our {!Transport} implementation we can include the logic
    that goes on top of it: *)
 include Dns_client.Make(Transport)
+
+(* initialize the RNG *)
+let () = Mirage_crypto_rng_unix.initialize ()

--- a/unix/client/dns_client_unix.mli
+++ b/unix/client/dns_client_unix.mli
@@ -1,5 +1,7 @@
 (** [Unix] helper module for {!Dns_client}.
     For more information see the {!Dns_client.Make} functor.
+
+    It initializes the RNG (using Mirage_crypto_rng_unix.initialize ()).
 *)
 
 


### PR DESCRIPTION
now that the lwt initialize is not in the lwt event loop, and also safe to be called multiple times (only the first call will do any work), it is good to call in the library code on top level.