### PR TITLE
client (unix, lwt): in "create" parse /etc/resolv.conf and use first IPv4 address of a nameserver

### DIFF
--- a/lwt/client/dns_client_lwt.ml
+++ b/lwt/client/dns_client_lwt.ml
@@ -15,9 +15,38 @@ module Transport : Dns_client.S
   }
   type context = { t : t ; fd : Lwt_unix.file_descr ; timeout_ns : int64 ref }
 
-  let create
-    ?(nameserver = `TCP, (Unix.inet_addr_of_string Dns_client.default_resolver, 53))
-    ~timeout () =
+  let read_file file =
+    try
+      let fh = open_in file in
+      try
+        let content = really_input_string fh (in_channel_length fh) in
+        close_in_noerr fh ;
+        Ok content
+      with _ ->
+        close_in_noerr fh;
+        Error (`Msg ("Error reading file: " ^ file))
+    with _ -> Error (`Msg ("Error opening file " ^ file))
+
+  let create ?nameserver ~timeout () =
+    let nameserver =
+      Rresult.R.(get_ok (of_option ~none:(fun () ->
+          let ip =
+            match
+              read_file "/etc/resolv.conf" >>= fun data ->
+              Dns_resolvconf.parse data >>= fun nameservers ->
+              List.fold_left (fun acc ns ->
+                  match acc, ns with
+                  | Ok ip, _ -> Ok ip
+                  | _, `Nameserver (Ipaddr.V4 ip) -> Ok ip
+                  | acc, _ -> acc)
+                (Error (`Msg "no nameserver")) nameservers
+            with
+            | Error _ -> Unix.inet_addr_of_string Dns_client.default_resolver
+            | Ok ip -> Ipaddr_unix.V4.to_inet_addr ip
+          in
+          Ok (`TCP, (ip, 53)))
+          nameserver))
+    in
     { nameserver ; timeout_ns = timeout }
 
   let nameserver { nameserver ; _ } = nameserver

--- a/lwt/client/dune
+++ b/lwt/client/dune
@@ -2,5 +2,5 @@
   (name        dns_client_lwt)
   (modules     dns_client_lwt)
   (public_name dns-client.lwt)
-  (libraries   lwt lwt.unix dns dns-client mtime.clock.os mirage-crypto-rng.lwt)
+  (libraries   lwt lwt.unix dns dns-client dns-client.resolvconf mtime.clock.os mirage-crypto-rng.lwt ipaddr.unix)
   (wrapped     false))

--- a/unix/client/dune
+++ b/unix/client/dune
@@ -2,7 +2,7 @@
   (name        dns_client_unix)
   (modules     dns_client_unix)
   (public_name dns-client.unix)
-  (libraries   domain-name ipaddr dns-client rresult unix mtime.clock.os mirage-crypto-rng.unix)
+  (libraries   domain-name ipaddr ipaddr.unix dns-client dns-client.resolvconf rresult unix mtime.clock.os mirage-crypto-rng.unix)
   (wrapped     false))
 
 (executable


### PR DESCRIPTION
this changes the default behaviour by using the system-configured nameserver(s).

there are some issues with this strategy:
- the system-configured nameserver may be UDP only, in which case the client will fail
- the first nameserver may be unreachable