### PR TITLE
DNS: revise TXT resource record encoding and storage

### DIFF
--- a/zone/dns_zone_parser.mly
+++ b/zone/dns_zone_parser.mly
@@ -134,9 +134,11 @@ generic_type s generic_rdata {
      { let mx = { Mx.preference = $3 ; mail_exchange = $5 } in
        B (Mx, (0l, Rr_map.Mx_set.singleton mx)) }
  | TYPE_TXT s charstrings
-     { if List.exists (fun s -> String.length s > 255) $3 then
-         parse_error "A single TXT rdata may not exceed 255 bytes";
-       B (Txt, (0l, Rr_map.Txt_set.of_list $3)) }
+     { let txt = String.concat "" $3 in
+       if String.length txt > 65279 then
+         (* there's only so much space for a RR - TXT needs for each 255 byte an extra length byte *)
+         parse_error "A single TXT rdata may not exceed 65279 bytes";
+       B (Txt, (0l, Rr_map.Txt_set.singleton txt)) }
      /* RFC 2782 */
  | TYPE_SRV s int16 s int16 s int16 s hostname
      { let srv = { Srv.priority = $3 ; weight = $5 ; port = $7 ; target = $9 } in


### PR DESCRIPTION
Previously, each TXT record hold a single string up to 255 characters in length.
When the length was exceeded, a new resource record was used. This is wasteful
(name, type, class, len needs to be repeated) and unexpected in some cases
(the requesting party gets multiple resource records which content needs to be
concatenated). The Txt.encode and Txt.decode did not behave in the same way
(decode split individual character strings, encode encoded only a single one).

When I tried to introduce some DKIM keys into my domains, I hit this issue that
DKIM check tools couldn't handle the responses from my servers. With this change
(and regression test):
(a) the Txt record can hold values that exceed 255 bytes
(b) in Txt.decode, a single resource record is a single entry in the map (the
    charstrings are concatenated)
(c) Txt.encode deals with values that exceed 255 bytes (by chunking them into
    255 byte long pieces, followed by a single byte length field, ...
(d) the zone parser is adapted to accept charstrings of length up to 65279
    bytes in a TXT entry (the rdlen is 16 bit (= 2 ^ 16), every 255 bytes we
    have to use 256)

This fixes #244.