### PR TITLE
dns-certify improvements and dual stack support

### DIFF
--- a/app/ocertify.ml
+++ b/app/ocertify.ml
@@ -151,7 +151,7 @@ let hostname =
 
 let more_hostnames =
   let doc = "Additional hostnames to be included in the certificate as SubjectAlternativeName extension" in
-  Arg.(value & opt_all Dns_cli.name_c [] & info ["additional"] ~doc ~docv:"HOSTNAME")
+  Arg.(value & opt_all Dns_cli.domain_name_c [] & info ["additional"] ~doc ~docv:"HOSTNAME")
 
 let csr =
   let doc = "certificate signing request filename (defaults to hostname.req)" in

--- a/certify/dns_certify.mli
+++ b/certify/dns_certify.mli
@@ -1,7 +1,7 @@
 open Dns
 
 val signing_request : [`host] Domain_name.t ->
-  ?more_hostnames:([`host] Domain_name.t list) ->
+  ?more_hostnames:([`raw] Domain_name.t list) ->
   X509.Private_key.t -> X509.Signing_request.t
 (** [signing_request name ~more_hostnames key] creates a X509 signing request
     where [name] will be the common name in its subject, and if [more_hostnames]

--- a/dns-certify.opam
+++ b/dns-certify.opam
@@ -21,7 +21,7 @@ depends: [
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-stack" {>= "2.0.0"}
+  "mirage-stack" {>= "2.2.0"}
   "logs"
   "mirage-crypto-pk" {>= "0.8.0"}
   "mirage-crypto-rng" {>= "0.8.0"}

--- a/dns-certify.opam
+++ b/dns-certify.opam
@@ -17,7 +17,6 @@ depends: [
   "duration" {>= "0.1.2"}
   "x509" {>= "0.10.0"}
   "lwt" {>= "4.2.1"}
-  "tls" {>= "0.11.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/dns-client.opam
+++ b/dns-client.opam
@@ -24,7 +24,7 @@ depends: [
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}
-  "mirage-stack" {>= "2.0.0"}
+  "mirage-stack" {>= "2.2.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/dns-mirage.opam
+++ b/dns-mirage.opam
@@ -13,7 +13,7 @@ depends: [
   "dns" {= version}
   "ipaddr" {>= "4.0.0"}
   "lwt" {>= "4.2.1"}
-  "mirage-stack" {>= "2.0.0"}
+  "mirage-stack" {>= "2.2.0"}
 ]
 
 build: [

--- a/dns-server.opam
+++ b/dns-server.opam
@@ -17,7 +17,7 @@ depends: [
   "lwt" {>= "4.2.1"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-stack" {>= "2.0.0"}
+  "mirage-stack" {>= "2.2.0"}
   "mirage-crypto-rng" {with-test}
   "alcotest" {with-test}
   "dns-tsig" {with-test}

--- a/dns-stub.opam
+++ b/dns-stub.opam
@@ -22,7 +22,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-random" {>= "2.0.0"}
-  "mirage-stack" {>= "2.0.0"}
+  "mirage-stack" {>= "2.2.0"}
   "metrics"
 ]
 

--- a/mirage/certify/dns_certify_mirage.ml
+++ b/mirage/certify/dns_certify_mirage.ml
@@ -114,5 +114,5 @@ module Make (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (TIME : Mirage_time.
         S.TCP.close (D.flow flow) >|= fun () ->
         match certificate with
         | Error e -> Error e
-        | Ok (cert, chain) -> Ok (`Single (cert :: chain, priv))
+        | Ok (cert, chain) -> Ok (cert :: chain, priv)
 end

--- a/mirage/certify/dns_certify_mirage.ml
+++ b/mirage/certify/dns_certify_mirage.ml
@@ -5,7 +5,7 @@ open Lwt.Infix
 let src = Logs.Src.create "dns_certify_mirage" ~doc:"effectful DNS certify"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-module Make (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (TIME : Mirage_time.S) (S : Mirage_stack.V4) = struct
+module Make (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (TIME : Mirage_time.S) (S : Mirage_stack.V4V6) = struct
 
   module D = Dns_mirage.Make(S)
 
@@ -104,14 +104,14 @@ module Make (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (TIME : Mirage_time.
       Lwt.fail_with "hostname not a subdomain of zone provided by dns_key"
     else
       let priv, csr = initialise_csr hostname additional_hostnames key_seed in
-      S.TCPV4.create_connection (S.tcpv4 stack) (dns, port) >>= function
+      S.TCP.create_connection (S.tcp stack) (dns, port) >>= function
       | Error e ->
-        Log.err (fun m -> m "error %a while connecting to name server, shutting down" S.TCPV4.pp_error e) ;
+        Log.err (fun m -> m "error %a while connecting to name server, shutting down" S.TCP.pp_error e) ;
         Lwt.return (Error (`Msg "couldn't connect to name server"))
       | Ok flow ->
         let flow = D.of_flow flow in
         query_certificate_or_csr flow hostname keyname zone dnskey csr >>= fun certificate ->
-        S.TCPV4.close (D.flow flow) >|= fun () ->
+        S.TCP.close (D.flow flow) >|= fun () ->
         match certificate with
         | Error e -> Error e
         | Ok (cert, chain) -> Ok (`Single (cert :: chain, priv))

--- a/mirage/certify/dns_certify_mirage.mli
+++ b/mirage/certify/dns_certify_mirage.mli
@@ -3,7 +3,7 @@ module Make (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S) 
 
   val retrieve_certificate :
     S.t -> dns_key:string -> hostname:[ `host ] Domain_name.t ->
-    ?additional_hostnames:[ `host ] Domain_name.t list -> ?key_seed:string ->
+    ?additional_hostnames:[ `raw ] Domain_name.t list -> ?key_seed:string ->
     S.TCPV4.ipaddr -> int -> (Tls.Config.own_cert, [ `Msg of string ]) result Lwt.t
   (** [retrieve_certificate stack ~dns_key ~hostname ~key_seed server_ip port]
      generates a RSA private key (using the [key_seed]), a certificate

--- a/mirage/certify/dns_certify_mirage.mli
+++ b/mirage/certify/dns_certify_mirage.mli
@@ -4,7 +4,9 @@ module Make (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S) 
   val retrieve_certificate :
     S.t -> dns_key:string -> hostname:[ `host ] Domain_name.t ->
     ?additional_hostnames:[ `raw ] Domain_name.t list -> ?key_seed:string ->
-    S.TCP.ipaddr -> int -> (Tls.Config.own_cert, [ `Msg of string ]) result Lwt.t
+    S.TCP.ipaddr -> int ->
+    (X509.Certificate.t list * Mirage_crypto_pk.Rsa.priv,
+     [ `Msg of string ]) result Lwt.t
   (** [retrieve_certificate stack ~dns_key ~hostname ~key_seed server_ip port]
      generates a RSA private key (using the [key_seed]), a certificate
      signing request for the given [hostname] and [additional_hostnames], and

--- a/mirage/certify/dns_certify_mirage.mli
+++ b/mirage/certify/dns_certify_mirage.mli
@@ -1,10 +1,10 @@
 (* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
-module Make (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4) : sig
+module Make (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4V6) : sig
 
   val retrieve_certificate :
     S.t -> dns_key:string -> hostname:[ `host ] Domain_name.t ->
     ?additional_hostnames:[ `raw ] Domain_name.t list -> ?key_seed:string ->
-    S.TCPV4.ipaddr -> int -> (Tls.Config.own_cert, [ `Msg of string ]) result Lwt.t
+    S.TCP.ipaddr -> int -> (Tls.Config.own_cert, [ `Msg of string ]) result Lwt.t
   (** [retrieve_certificate stack ~dns_key ~hostname ~key_seed server_ip port]
      generates a RSA private key (using the [key_seed]), a certificate
      signing request for the given [hostname] and [additional_hostnames], and

--- a/mirage/certify/dune
+++ b/mirage/certify/dune
@@ -2,4 +2,4 @@
  (name dns_certify_mirage)
  (public_name dns-certify.mirage)
  (wrapped false)
- (libraries dns dns-mirage dns-certify mirage-crypto-rng mirage-crypto-pk tls lwt duration mirage-random mirage-time mirage-clock mirage-stack))
+ (libraries dns dns-mirage dns-certify mirage-crypto-rng mirage-crypto-pk lwt duration mirage-random mirage-time mirage-clock mirage-stack))

--- a/mirage/client/dns_client_mirage.ml
+++ b/mirage/client/dns_client_mirage.ml
@@ -3,14 +3,14 @@ open Lwt.Infix
 let src = Logs.Src.create "dns_client_mirage" ~doc:"effectful DNS client layer"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-module Make (R : Mirage_random.S) (T : Mirage_time.S) (C : Mirage_clock.MCLOCK) (S : Mirage_stack.V4) = struct
+module Make (R : Mirage_random.S) (T : Mirage_time.S) (C : Mirage_clock.MCLOCK) (S : Mirage_stack.V4V6) = struct
 
   module Transport : Dns_client.S
     with type stack = S.t
      and type +'a io = 'a Lwt.t
-     and type io_addr = Ipaddr.V4.t * int = struct
+     and type io_addr = Ipaddr.t * int = struct
     type stack = S.t
-    type io_addr = Ipaddr.V4.t * int
+    type io_addr = Ipaddr.t * int
     type ns_addr = [`TCP | `UDP] * io_addr
     type +'a io = 'a Lwt.t
     type t = {
@@ -18,10 +18,10 @@ module Make (R : Mirage_random.S) (T : Mirage_time.S) (C : Mirage_clock.MCLOCK) 
       timeout_ns : int64 ;
       stack : stack ;
     }
-    type context = { t : t ; flow : S.TCPV4.flow ; timeout_ns : int64 ref }
+    type context = { t : t ; flow : S.TCP.flow ; timeout_ns : int64 ref }
 
     let create
-        ?(nameserver = `TCP, (Ipaddr.V4.of_string_exn Dns_client.default_resolver, 53))
+        ?(nameserver = `TCP, (Ipaddr.V4 (Ipaddr.V4.of_string_exn Dns_client.default_resolver), 53))
         ~timeout
         stack =
       { nameserver ; timeout_ns = timeout ; stack }
@@ -44,45 +44,26 @@ module Make (R : Mirage_random.S) (T : Mirage_time.S) (C : Mirage_clock.MCLOCK) 
     let connect ?nameserver:ns t =
       let _proto, addr = match ns with None -> nameserver t | Some x -> x in
       let time_left = ref t.timeout_ns in
-      with_timeout time_left (S.TCPV4.create_connection (S.tcpv4 t.stack) addr >|= function
+      with_timeout time_left (S.TCP.create_connection (S.tcp t.stack) addr >|= function
       | Error e ->
         Log.err (fun m -> m "error connecting to nameserver %a"
-                    S.TCPV4.pp_error e) ;
+                    S.TCP.pp_error e) ;
         Error (`Msg "connect failure")
       | Ok flow -> Ok { t ; flow ; timeout_ns = time_left })
 
-    let close { flow ; _ } = S.TCPV4.close flow
+    let close { flow ; _ } = S.TCP.close flow
 
     let recv ctx =
-      with_timeout ctx.timeout_ns (S.TCPV4.read ctx.flow >|= function
-      | Error e -> Error (`Msg (Fmt.to_to_string S.TCPV4.pp_error e))
+      with_timeout ctx.timeout_ns (S.TCP.read ctx.flow >|= function
+      | Error e -> Error (`Msg (Fmt.to_to_string S.TCP.pp_error e))
       | Ok (`Data cs) -> Ok cs
       | Ok `Eof -> Ok Cstruct.empty)
 
     let send ctx s =
-      with_timeout ctx.timeout_ns (S.TCPV4.write ctx.flow s >|= function
-      | Error e -> Error (`Msg (Fmt.to_to_string S.TCPV4.pp_write_error e))
+      with_timeout ctx.timeout_ns (S.TCP.write ctx.flow s >|= function
+      | Error e -> Error (`Msg (Fmt.to_to_string S.TCP.pp_write_error e))
       | Ok () -> Ok ())
   end
 
   include Dns_client.Make(Transport)
 end
-
-(*
-type dns_ty = Dns_client
-
-let config : 'a Mirage.impl =
-  let open Mirage in
-  impl @@ object inherit Mirage.base_configurable
-    method module_name = "Dns_client"
-    method name = "Dns_client"
-    method ty : 'a typ = Type Dns_client
-    method! packages : package list value =
-      (Key.match_ Key.(value target) @@ begin function
-          | `Unix -> [package "dns-client.unix"]
-          | _ -> []
-        end
-      )
-    method! deps = []
-  end
-*)

--- a/mirage/client/dns_client_mirage.mli
+++ b/mirage/client/dns_client_mirage.mli
@@ -1,7 +1,7 @@
 
-module Make (R : Mirage_random.S) (T : Mirage_time.S) (C : Mirage_clock.MCLOCK) (S : Mirage_stack.V4) : sig
+module Make (R : Mirage_random.S) (T : Mirage_time.S) (C : Mirage_clock.MCLOCK) (S : Mirage_stack.V4V6) : sig
   module Transport : Dns_client.S
-    with type io_addr = Ipaddr.V4.t * int
+    with type io_addr = Ipaddr.t * int
      and type +'a io = 'a Lwt.t
      and type stack = S.t
 
@@ -12,16 +12,3 @@ module Make (R : Mirage_random.S) (T : Mirage_time.S) (C : Mirage_clock.MCLOCK) 
       random number generator and timestamp source, and calls the generic
       {!Dns_client.Make.create}. *)
 end
-
-(*
-type dns_ty
-
-val config : dns_ty Mirage.impl
-(** [config] is the *)
-
-module Make :
-  functor (Time:Mirage_time_lwt.S) ->
-  functor (IPv4:Mirage_stack_lwt.V4) ->
-    S
-
-*)

--- a/mirage/dns_mirage.ml
+++ b/mirage/dns_mirage.ml
@@ -7,17 +7,17 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 module Make (S : Mirage_stack.V4V6) = struct
 
-  module IS = Set.Make(Ipaddr.V4)
+  module IS = Set.Make(Ipaddr)
 
   module IM = struct
-    include Map.Make(Ipaddr.V4)
+    include Map.Make(Ipaddr)
     let find k t = try Some (find k t) with Not_found -> None
   end
 
   module IPM = struct
     include Map.Make(struct
-        type t = Ipaddr.V4.t * int
-        let compare (ip, p) (ip', p') = match Ipaddr.V4.compare ip ip' with
+        type t = Ipaddr.t * int
+        let compare (ip, p) (ip', p') = match Ipaddr.compare ip ip' with
           | 0 -> compare p p'
           | x -> x
       end)

--- a/mirage/dns_mirage.mli
+++ b/mirage/dns_mirage.mli
@@ -2,18 +2,18 @@
 
 module Make (S : Mirage_stack.V4V6) : sig
 
-  module IS : Set.S with type elt = Ipaddr.V4.t
+  module IS : Set.S with type elt = Ipaddr.t
   (** [IS] is a set of [ipaddr]. *)
 
   module IM : sig
-    include Map.S with type key = Ipaddr.V4.t
-    val find : Ipaddr.V4.t -> 'a t -> 'a option
+    include Map.S with type key = Ipaddr.t
+    val find : Ipaddr.t -> 'a t -> 'a option
   end
   (** [IM] is a map using [ipaddr] as key. *)
 
   module IPM : sig
-    include Map.S with type key = Ipaddr.V4.t * int
-    val find : Ipaddr.V4.t * int -> 'a t -> 'a option
+    include Map.S with type key = Ipaddr.t * int
+    val find : Ipaddr.t * int -> 'a t -> 'a option
   end
   (** [IPM] is a map using [ip * port] as key. *)
 

--- a/mirage/dns_mirage.mli
+++ b/mirage/dns_mirage.mli
@@ -1,6 +1,6 @@
 (* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 
-module Make (S : Mirage_stack.V4) : sig
+module Make (S : Mirage_stack.V4V6) : sig
 
   module IS : Set.S with type elt = Ipaddr.V4.t
   (** [IS] is a set of [ipaddr]. *)
@@ -21,25 +21,25 @@ module Make (S : Mirage_stack.V4) : sig
   (** A 2byte-length per message flow abstraction, the embedding of DNS frames
      via TCP. *)
 
-  val of_flow : S.TCPV4.flow -> f
+  val of_flow : S.TCP.flow -> f
   (** [of_flow flow] is [f]. *)
 
-  val flow : f -> S.TCPV4.flow
+  val flow : f -> S.TCP.flow
   (** [flow f] is the underlying flow. *)
 
   val read_tcp : f -> (Cstruct.t, unit) result Lwt.t
   (** [read_tcp f] returns either a buffer or an error (logs actual error). *)
 
-  val send_tcp : S.TCPV4.flow -> Cstruct.t -> (unit, unit) result Lwt.t
+  val send_tcp : S.TCP.flow -> Cstruct.t -> (unit, unit) result Lwt.t
   (** [send_tcp flow buf] sends the buffer, either succeeds or fails (logs
       actual error). *)
 
-  val send_tcp_multiple : S.TCPV4.flow -> Cstruct.t list ->
+  val send_tcp_multiple : S.TCP.flow -> Cstruct.t list ->
     (unit, unit) result Lwt.t
   (** [send_tcp_multiple flow bufs] sends the buffers, either succeeds or fails
       (logs actual error). *)
 
-  val send_udp : S.t -> int -> Ipaddr.V4.t -> int -> Cstruct.t -> unit Lwt.t
+  val send_udp : S.t -> int -> Ipaddr.t -> int -> Cstruct.t -> unit Lwt.t
   (** [send_udp stack source_port dst dst_port buf] sends the [buf] as UDP
      packet to [dst] on [dst_port]. *)
 end

--- a/mirage/resolver/dns_resolver_mirage.mli
+++ b/mirage/resolver/dns_resolver_mirage.mli
@@ -1,6 +1,6 @@
 (* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 
-module Make (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4) : sig
+module Make (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4V6) : sig
 
   val resolver : S.t -> ?root:bool -> ?timer:int -> ?port:int -> Dns_resolver.t -> unit
   (** [resolver stack ~root ~timer ~port resolver] registers a caching resolver

--- a/mirage/server/dns_server_mirage.mli
+++ b/mirage/server/dns_server_mirage.mli
@@ -1,9 +1,9 @@
 (* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 
-module Make (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4) : sig
+module Make (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4V6) : sig
 
   val primary :
-    ?on_update:(old:Dns_trie.t -> authenticated_key:[`raw] Domain_name.t option -> update_source:Ipaddr.V4.t -> Dns_server.Primary.s -> unit Lwt.t) ->
+    ?on_update:(old:Dns_trie.t -> authenticated_key:[`raw] Domain_name.t option -> update_source:Ipaddr.t -> Dns_server.Primary.s -> unit Lwt.t) ->
     ?on_notify:([ `Notify of Dns.Soa.t option | `Signed_notify of Dns.Soa.t option ] ->
                 Dns_server.Primary.s ->
                 (Dns_trie.t * ([ `raw ] Domain_name.t * Dns.Dnskey.t) list) option Lwt.t) ->

--- a/resolver/dns_resolver.mli
+++ b/resolver/dns_resolver.mli
@@ -8,23 +8,23 @@ val create : ?size:int -> ?mode:[ `Recursive | `Stub ] -> int64 ->
 (** [create ~size ~mode now rng primary] creates the value of a resolver,
    pre-filled with root NS and their IP addresses. *)
 
-val handle_buf : t -> Ptime.t -> int64 -> bool -> Dns.proto -> Ipaddr.V4.t ->
+val handle_buf : t -> Ptime.t -> int64 -> bool -> Dns.proto -> Ipaddr.t ->
   int -> Cstruct.t ->
-  t * (Dns.proto * Ipaddr.V4.t * int * Cstruct.t) list
-    * (Dns.proto * Ipaddr.V4.t * Cstruct.t) list
+  t * (Dns.proto * Ipaddr.t * int * Cstruct.t) list
+    * (Dns.proto * Ipaddr.t * Cstruct.t) list
 (** [handle_buf t now ts query_or_reply proto sender source-port buf] handles
    resolution of [buf], which leads to a new [t], a list of answers to be
    transmitted (quadruple of protocol, ip address, port, buffer), and a list of
    queries (triple of protocol, ip address, buffer). *)
 
 val query_root : t -> int64 -> Dns.proto ->
-  t * (Dns.proto * Ipaddr.V4.t * Cstruct.t)
+  t * (Dns.proto * Ipaddr.t * Cstruct.t)
 (** [query_root t now proto] potentially requests an update of the root
    zone. Best invoked by a regular timer. *)
 
 val timer : t -> int64 ->
-  t * (Dns.proto * Ipaddr.V4.t * int * Cstruct.t) list
-    * (Dns.proto * Ipaddr.V4.t * Cstruct.t) list
+  t * (Dns.proto * Ipaddr.t * int * Cstruct.t) list
+    * (Dns.proto * Ipaddr.t * Cstruct.t) list
 (** [timer t now] potentially retransmits DNS requests and/or sends NXDomain
     answers. *)
 

--- a/resolver/dns_resolver_cache.mli
+++ b/resolver/dns_resolver_cache.mli
@@ -62,14 +62,14 @@ val resolve_ns : t -> int64 -> Domain_name.t ->
 *)
 
 (*val find_ns : t -> (int -> Cstruct.t) -> int64 -> Domain_name.Set.t -> Domain_name.t ->
-  [ `Loop | `NeedNS | `NoDom | `No | `Cname of Domain_name.t | `HaveIP of Ipaddr.V4.t | `NeedA of Domain_name.t | `NeedGlue of Domain_name.t ] * t
+  [ `Loop | `NeedNS | `NoDom | `No | `Cname of Domain_name.t | `HaveIP of Ipaddr.t | `NeedA of Domain_name.t | `NeedGlue of Domain_name.t ] * t
 *)
 
 val resolve : t -> rng:(int -> Cstruct.t) ->  int64 -> [ `raw ] Domain_name.t ->
-  Rr_map.k -> [ `raw ] Domain_name.t * [ `raw ] Domain_name.t * Rr_map.k * Ipaddr.V4.t * t
+  Rr_map.k -> [ `raw ] Domain_name.t * [ `raw ] Domain_name.t * Rr_map.k * Ipaddr.t * t
 
 val handle_query : t -> rng:(int -> Cstruct.t) -> int64 -> [ `raw ] Domain_name.t ->
   Packet.Question.qtype ->
   [ `Reply of Packet.Flags.t * Packet.reply
   | `Nothing
-  | `Query of [ `raw ] Domain_name.t * ([ `raw ] Domain_name.t * Packet.Question.qtype) * Ipaddr.V4.t ] * t
+  | `Query of [ `raw ] Domain_name.t * ([ `raw ] Domain_name.t * Packet.Question.qtype) * Ipaddr.t ] * t

--- a/server/dns_server.mli
+++ b/server/dns_server.mli
@@ -114,12 +114,12 @@ module Primary : sig
   (** [data s] is the data store of [s]. *)
 
   val with_data : s -> Ptime.t -> int64 -> Dns_trie.t ->
-    s * (Ipaddr.V4.t * Cstruct.t list) list
+    s * (Ipaddr.t * Cstruct.t list) list
   (** [with_data s now ts trie] replaces the current data with [trie] in [s].
       The returned notifications should be send out. *)
 
   val with_keys : s -> Ptime.t -> int64 -> ('a Domain_name.t * Dnskey.t) list ->
-    s * (Ipaddr.V4.t * Cstruct.t list) list
+    s * (Ipaddr.t * Cstruct.t list) list
   (** [with_keys s now ts keys] replaces the current keys with [keys] in [s],
       and generates notifications. *)
 
@@ -133,17 +133,17 @@ module Primary : sig
      data] creates a primary server. If [unauthenticated_zone_transfer] is
      provided and [true] (defaults to [false]), anyone can transfer the zones. *)
 
-  val handle_packet : s -> Ptime.t -> int64 -> proto -> Ipaddr.V4.t -> int ->
+  val handle_packet : s -> Ptime.t -> int64 -> proto -> Ipaddr.t -> int ->
     Packet.t -> 'a Domain_name.t option ->
-    s * Packet.t option * (Ipaddr.V4.t * Cstruct.t list) list *
+    s * Packet.t option * (Ipaddr.t * Cstruct.t list) list *
     [> `Notify of Soa.t option | `Keep ] option
   (** [handle_packet s now ts src src_port proto key packet] handles the given
      [packet], returning new state, an answer, and potentially notify packets to
      secondary name servers. *)
 
   val handle_buf : s -> Ptime.t -> int64 -> proto ->
-    Ipaddr.V4.t -> int -> Cstruct.t ->
-    s * Cstruct.t list * (Ipaddr.V4.t * Cstruct.t list) list *
+    Ipaddr.t -> int -> Cstruct.t ->
+    s * Cstruct.t list * (Ipaddr.t * Cstruct.t list) list *
     [ `Notify of Soa.t option | `Signed_notify of Soa.t option | `Keep ] option *
     [ `raw ] Domain_name.t option
   (** [handle_buf s now ts proto src src_port buffer] decodes the [buffer],
@@ -152,16 +152,16 @@ module Primary : sig
      a list of notifications to send out, information whether a notify (or
      signed notify) was received, and the hmac key used for authentication. *)
 
-  val closed : s -> Ipaddr.V4.t -> s
+  val closed : s -> Ipaddr.t -> s
   (** [closed s ip] marks the connection to [ip] closed. *)
 
   val timer : s -> Ptime.t -> int64 ->
-    s * (Ipaddr.V4.t * Cstruct.t list) list
+    s * (Ipaddr.t * Cstruct.t list) list
   (** [timer s now ts] may encode some notifications to secondary name servers
      if previous ones were not acknowledged. *)
 
   val to_be_notified : s -> [ `host ] Domain_name.t ->
-    (Ipaddr.V4.t * [ `raw ] Domain_name.t option) list
+    (Ipaddr.t * [ `raw ] Domain_name.t option) list
   (** [to_be_notified s zone] returns a list of pairs of IP address and optional
      tsig key name of the servers to be notified for a zone change.  This list
      is based on (a) NS entries for the zone, (b) registered TSIG transfer keys,
@@ -179,27 +179,27 @@ module Secondary : sig
   val with_data : s -> Dns_trie.t -> s
   (** [with_data s trie] is [s] with its data replaced by [trie]. *)
 
-  val create : ?primary:Ipaddr.V4.t ->
+  val create : ?primary:Ipaddr.t ->
    tsig_verify:Tsig_op.verify -> tsig_sign:Tsig_op.sign ->
     rng:(int -> Cstruct.t) -> ('a Domain_name.t * Dnskey.t) list -> s
   (** [create ~primary ~tsig_verify ~tsig_sign ~rng keys] creates a secondary
      DNS server state. *)
 
-  val handle_packet : s -> Ptime.t -> int64 -> Ipaddr.V4.t ->
+  val handle_packet : s -> Ptime.t -> int64 -> Ipaddr.t ->
     Packet.t -> 'a Domain_name.t option ->
-    s * Packet.t option * (Ipaddr.V4.t * Cstruct.t) option
+    s * Packet.t option * (Ipaddr.t * Cstruct.t) option
   (** [handle_packet s now ts ip proto key t] handles the incoming packet. *)
 
-  val handle_buf : s -> Ptime.t -> int64 -> proto -> Ipaddr.V4.t -> Cstruct.t ->
-    s * Cstruct.t option * (Ipaddr.V4.t * Cstruct.t) option
+  val handle_buf : s -> Ptime.t -> int64 -> proto -> Ipaddr.t -> Cstruct.t ->
+    s * Cstruct.t option * (Ipaddr.t * Cstruct.t) option
   (** [handle_buf s now ts proto src buf] decodes [buf], processes with
       {!handle_packet}, and encodes the results. *)
 
   val timer : s -> Ptime.t -> int64 ->
-    s * (Ipaddr.V4.t * Cstruct.t list) list
+    s * (Ipaddr.t * Cstruct.t list) list
   (** [timer s now ts] may request SOA or retransmit AXFR. *)
 
-  val closed : s -> Ptime.t -> int64 -> Ipaddr.V4.t ->
+  val closed : s -> Ptime.t -> int64 -> Ipaddr.t ->
     s * Cstruct.t list
   (** [closed s now ts ip] marks [ip] as closed, the returned buffers (SOA
       requests) should be sent to [ip]. *)

--- a/test/server.ml
+++ b/test/server.ml
@@ -459,7 +459,7 @@ end
 
 module S = struct
 
-  let ip =
+  let ipv4 =
     let module M = struct
       type t = Ipaddr.V4.t
       let pp = Ipaddr.V4.pp
@@ -467,9 +467,19 @@ module S = struct
     end in
     (module M : Alcotest.TESTABLE with type t = M.t)
 
-  let ipset = Alcotest.(slist ip Ipaddr.V4.compare)
+  let ip =
+    let module M = struct
+      type t = Ipaddr.t
+      let pp = Ipaddr.pp
+      let equal a b = Ipaddr.compare a b = 0
+    end in
+    (module M : Alcotest.TESTABLE with type t = M.t)
 
-  let ip_of_s = Ipaddr.V4.of_string_exn
+  let ipset = Alcotest.(slist ip Ipaddr.compare)
+
+  let ipv4_of_s = Ipaddr.V4.of_string_exn
+
+  let ip_of_s s = Ipaddr.V4 (ipv4_of_s s)
 
   let ts = Duration.of_sec 5
 
@@ -498,7 +508,7 @@ module S = struct
       in
       Dns_trie.insert (n_of_s "one.com") Rr_map.Ns (300l, ns)
         (Dns_trie.insert (n_of_s "ns2.one.com") Rr_map.A
-           (300l, Rr_map.Ipv4_set.singleton (ip_of_s "10.0.0.2")) data)
+           (300l, Rr_map.Ipv4_set.singleton (ipv4_of_s "10.0.0.2")) data)
     in
     let server = Dns_server.Primary.create ~rng:Mirage_crypto_rng.generate data in
     let _, notifications = Dns_server.Primary.timer server Ptime.epoch ts in
@@ -515,7 +525,7 @@ module S = struct
       in
       Dns_trie.insert (n_of_s "one.com") Rr_map.Ns (300l, ns)
         (Dns_trie.insert (n_of_s "ns2.two.com") Rr_map.A
-           (300l, Rr_map.Ipv4_set.singleton (ip_of_s "10.0.0.2")) data)
+           (300l, Rr_map.Ipv4_set.singleton (ipv4_of_s "10.0.0.2")) data)
     in
     let server = Dns_server.Primary.create ~rng:Mirage_crypto_rng.generate data in
     let _, notifications = Dns_server.Primary.timer server Ptime.epoch ts in
@@ -530,7 +540,7 @@ module S = struct
         Domain_name.(Host_set.(add (host_exn (n_of_s "ns.one.com"))
                                  (singleton (host_exn (n_of_s "ns2.one.com")))))
       and ips =
-        Rr_map.Ipv4_set.(add (ip_of_s "10.0.0.2") (singleton (ip_of_s "1.2.3.4")))
+        Rr_map.Ipv4_set.(add (ipv4_of_s "10.0.0.2") (singleton (ipv4_of_s "1.2.3.4")))
       in
       Dns_trie.insert (n_of_s "one.com") Rr_map.Ns (300l, ns)
         (Dns_trie.insert (n_of_s "ns2.one.com") Rr_map.A (300l, ips) data)
@@ -551,9 +561,9 @@ module S = struct
       in
       Dns_trie.insert (n_of_s "one.com") Rr_map.Ns (300l, ns)
         (Dns_trie.insert (n_of_s "ns2.one.com") Rr_map.A
-           (300l, Rr_map.Ipv4_set.singleton (ip_of_s "10.0.0.2"))
+           (300l, Rr_map.Ipv4_set.singleton (ipv4_of_s "10.0.0.2"))
            (Dns_trie.insert (n_of_s "ns3.one.com") Rr_map.A
-              (300l, Rr_map.Ipv4_set.singleton (ip_of_s "10.0.0.3"))
+              (300l, Rr_map.Ipv4_set.singleton (ipv4_of_s "10.0.0.3"))
               data))
     in
     let server = Dns_server.Primary.create ~rng:Mirage_crypto_rng.generate data' in
@@ -573,9 +583,9 @@ module S = struct
       in
       Dns_trie.insert (n_of_s "one.com") Rr_map.Ns (300l, ns)
         (Dns_trie.insert (n_of_s "ns2.one.com") Rr_map.A
-           (300l, Rr_map.Ipv4_set.(add (ip_of_s "10.0.0.2") (singleton (ip_of_s "10.0.0.3"))))
+           (300l, Rr_map.Ipv4_set.(add (ipv4_of_s "10.0.0.2") (singleton (ipv4_of_s "10.0.0.3"))))
            (Dns_trie.insert (n_of_s "ns3.one.com") Rr_map.A
-              (300l, Rr_map.Ipv4_set.(add (ip_of_s "10.0.0.3") (singleton (ip_of_s "10.0.0.4"))))
+              (300l, Rr_map.Ipv4_set.(add (ipv4_of_s "10.0.0.3") (singleton (ipv4_of_s "10.0.0.4"))))
               data))
     in
     let server = Dns_server.Primary.create ~rng:Mirage_crypto_rng.generate data' in
@@ -602,11 +612,11 @@ module S = struct
            (Dns_trie.insert (n_of_s "foo.com") Rr_map.Soa soa'
               (Dns_trie.insert (n_of_s "bar.com") Rr_map.Soa soa''
                  (Dns_trie.insert (n_of_s "ns.foo.com") Rr_map.A
-                    (300l, Rr_map.Ipv4_set.singleton (ip_of_s "10.0.0.2"))
+                    (300l, Rr_map.Ipv4_set.singleton (ipv4_of_s "10.0.0.2"))
                     (Dns_trie.insert (n_of_s "ns.bar.com") Rr_map.A
-                       (300l, Rr_map.Ipv4_set.singleton (ip_of_s "10.0.0.3"))
+                       (300l, Rr_map.Ipv4_set.singleton (ipv4_of_s "10.0.0.3"))
                        (Dns_trie.insert (n_of_s "ns.one.com") Rr_map.A
-                          (300l, Rr_map.Ipv4_set.singleton (ip_of_s "10.0.0.4"))
+                          (300l, Rr_map.Ipv4_set.singleton (ipv4_of_s "10.0.0.4"))
                           Dns_trie.empty))))))
     in
     let server = Dns_server.Primary.create ~rng:Mirage_crypto_rng.generate data in
@@ -654,9 +664,9 @@ module S = struct
       in
       Dns_trie.insert (n_of_s "one.com") Rr_map.Ns (300l, ns)
         (Dns_trie.insert (n_of_s "ns2.one.com") Rr_map.A
-           (300l, Rr_map.Ipv4_set.singleton (ip_of_s "1.1.1.1"))
+           (300l, Rr_map.Ipv4_set.singleton (ipv4_of_s "1.1.1.1"))
            (Dns_trie.insert (n_of_s "ns3.one.com") Rr_map.A
-              (300l, Rr_map.Ipv4_set.(add (ip_of_s "10.0.0.1") (singleton (ip_of_s "192.168.1.1"))))
+              (300l, Rr_map.Ipv4_set.(add (ipv4_of_s "10.0.0.1") (singleton (ipv4_of_s "192.168.1.1"))))
               data))
     in
     let server = Dns_server.Primary.create ~rng:Mirage_crypto_rng.generate ~keys data' in
@@ -680,9 +690,9 @@ module S = struct
       in
       Dns_trie.insert (n_of_s "one.com") Rr_map.Ns (300l, ns)
         (Dns_trie.insert (n_of_s "ns2.one.com") Rr_map.A
-           (300l, Rr_map.Ipv4_set.singleton (ip_of_s "5.6.7.8"))
+           (300l, Rr_map.Ipv4_set.singleton (ipv4_of_s "5.6.7.8"))
            (Dns_trie.insert (n_of_s "ns3.one.com") Rr_map.A
-              (300l, Rr_map.Ipv4_set.(add (ip_of_s "10.0.0.1") (singleton (ip_of_s "192.168.1.1"))))
+              (300l, Rr_map.Ipv4_set.(add (ipv4_of_s "10.0.0.1") (singleton (ipv4_of_s "192.168.1.1"))))
               data))
     in
     let server = Dns_server.Primary.create ~rng:Mirage_crypto_rng.generate ~keys data' in
@@ -1332,7 +1342,7 @@ module Axfr = struct
       fst (Packet.encode `Tcp res)
     in
     let _server', answers, _notifies, _notify, _key =
-      Dns_server.Primary.handle_buf server Ptime.epoch 0L `Tcp Ipaddr.V4.localhost 1234 req
+      Dns_server.Primary.handle_buf server Ptime.epoch 0L `Tcp (Ipaddr.V4 Ipaddr.V4.localhost) 1234 req
     in
     answers
 
@@ -1481,7 +1491,7 @@ module Axfr = struct
       | Error _ -> assert false
     in
     let _server', answers, _notifies, _notify, keyname' =
-      Dns_server.Primary.handle_buf server Ptime.epoch 0L `Tcp Ipaddr.V4.localhost 1234 req
+      Dns_server.Primary.handle_buf server Ptime.epoch 0L `Tcp (Ipaddr.V4 Ipaddr.V4.localhost) 1234 req
     in
     assert (match keyname' with Some k -> Domain_name.equal k keyname | _ -> false);
     (List.iter (fun answer ->


### PR DESCRIPTION
this includes improvements for dns-certify:
- allow ``[`raw] Domain_name.t`` for additional hostnames
- avoid dependency on tls, return `X509.Certificate.t list * Mirage_crypto_pk.RSA.priv` instead of `Tls.Config.own_cert` (makes this more composable as well)
- rebased dual stack patches from #239 