### PR TITLE
Fix decoding of tsig resource records

### DIFF
--- a/src/dns.mli
+++ b/src/dns.mli
@@ -1038,8 +1038,9 @@ module Packet : sig
      and optional EDNS and TSIG records. *)
 
   val create : ?max_size:int -> ?additional:Name_rr_map.t -> ?edns:Edns.t ->
+    ?tsig:([ `raw ] Domain_name.t * Tsig.t * int) ->
     Header.t -> Question.t -> data -> t
-  (** [create ~max_size ~additional ~edns hdr q data] is a DNS packet. *)
+  (** [create ~max_size ~additional ~edns ~tsig hdr q data] is a DNS packet. *)
 
   val with_edns : t -> Edns.t option -> t
   (** [with_edns t edns] is [t] with the edns field set to [edns]. *)


### PR DESCRIPTION
Previously, tsig carrying an error with a second timestamp in "other" attempted
to decode at a wrong offset. Now, the correct offset is used, and the ptime
construction is hardened.

Adds a regression test, which requires Dns.Packet.create to expose its ?tsig
argument.