### PR TITLE
API updates

### DIFF
--- a/app/odns.ml
+++ b/app/odns.ml
@@ -28,17 +28,16 @@ let pp_zone_tlsa ppf (domain,ttl,(tlsa:Dns.Tlsa.t)) =
         | n -> loop ((String.sub hex n 56)::acc) (n+56)
       in loop [] 0)
 
-let ns ip is_udp = match ip with
+let ns ip port is_udp = match ip with
   | None -> None
-  | Some ip -> if is_udp then Some (`UDP, ip) else Some (`TCP, ip)
+  | Some ip -> if is_udp then Some (`UDP, (ip, port)) else Some (`TCP, (ip, port))
 
-let do_a nameserver is_udp domains _ =
-  let nameserver = ns nameserver is_udp in
+let do_a nameserver ns_port is_udp domains _ =
+  let nameserver = ns nameserver ns_port is_udp in
   let t = Dns_client_lwt.create ?nameserver () in
   let (_, (ns_ip, _)) = Dns_client_lwt.nameserver t in
-  Logs.info (fun m -> m "querying NS %s for A records of %a"
-                (Unix.string_of_inet_addr ns_ip)
-                Fmt.(list ~sep:(unit", ") Domain_name.pp) domains);
+  Logs.info (fun m -> m "querying NS %a for A records of %a"
+                Ipaddr.pp ns_ip Fmt.(list ~sep:(unit", ") Domain_name.pp) domains);
   let job =
     Lwt_list.iter_p (fun domain ->
         let open Lwt in
@@ -60,14 +59,14 @@ let do_a nameserver is_udp domains _ =
   match Lwt_main.run job with
   | () -> Ok () (* TODO handle errors *)
 
-let for_all_domains nameserver is_udp ~domains typ f =
+let for_all_domains nameserver ns_port is_udp ~domains typ f =
   (* [for_all_domains] is a utility function that lets us avoid duplicating
      this block of code in all the subcommands.
      We leave {!do_a} simple to provide a more readable example. *)
-  let nameserver = ns nameserver is_udp in
+  let nameserver = ns nameserver ns_port is_udp in
   let t = Dns_client_lwt.create ?nameserver () in
   let _, (ns_ip, _) = Dns_client_lwt.nameserver t in
-  Logs.info (fun m -> m "NS: %s" @@ Unix.string_of_inet_addr ns_ip);
+  Logs.info (fun m -> m "NS: %a" Ipaddr.pp ns_ip);
   let open Lwt in
   match Lwt_main.run
           (Lwt_list.iter_p
@@ -88,16 +87,16 @@ let pp_response typ domain = function
   | Error _ -> ()
   | Ok resp -> Logs.app (fun m -> m "%a" pp_zone (domain, typ, resp))
 
-let do_aaaa nameserver is_udp domains _ =
-  for_all_domains nameserver is_udp ~domains Dns.Rr_map.Aaaa
+let do_aaaa nameserver ns_port is_udp domains _ =
+  for_all_domains nameserver ns_port is_udp ~domains Dns.Rr_map.Aaaa
     (pp_response Dns.Rr_map.Aaaa)
 
-let do_mx nameserver is_udp domains _ =
-  for_all_domains nameserver is_udp ~domains Dns.Rr_map.Mx
+let do_mx nameserver ns_port is_udp domains _ =
+  for_all_domains nameserver ns_port is_udp ~domains Dns.Rr_map.Mx
     (pp_response Dns.Rr_map.Mx)
 
-let do_tlsa nameserver is_udp domains _ =
-  for_all_domains nameserver is_udp ~domains Dns.Rr_map.Tlsa
+let do_tlsa nameserver ns_port is_udp domains _ =
+  for_all_domains nameserver ns_port is_udp ~domains Dns.Rr_map.Tlsa
     (fun domain -> function
        | Ok (ttl, tlsa_resp) ->
          Dns.Rr_map.Tlsa_set.iter (fun tlsa ->
@@ -106,8 +105,8 @@ let do_tlsa nameserver is_udp domains _ =
        | Error _ -> () )
 
 
-let do_txt nameserver is_udp domains _ =
-  for_all_domains nameserver is_udp ~domains Dns.Rr_map.Txt
+let do_txt nameserver ns_port is_udp domains _ =
+  for_all_domains nameserver ns_port is_udp ~domains Dns.Rr_map.Txt
     (fun _domain -> function
        | Ok (ttl, txtset) ->
          Dns.Rr_map.Txt_set.iter (fun txtrr ->
@@ -120,13 +119,13 @@ let do_any _nameserver _is_udp _domains _ =
   (* TODO *)
   Error (`Msg "ANY functionality is not present atm due to refactorings, come back later")
 
-let do_dkim nameserver is_udp (selector:string) domains _ =
+let do_dkim nameserver ns_port is_udp (selector:string) domains _ =
   let domains = List.map (fun original_domain ->
       Domain_name.prepend_label_exn
         (Domain_name.prepend_label_exn
            (original_domain) "_domainkey") selector
     ) domains in
-  for_all_domains nameserver is_udp ~domains Dns.Rr_map.Txt
+  for_all_domains nameserver ns_port is_udp ~domains Dns.Rr_map.Txt
     (fun _domain -> function
        | Ok (_ttl, txtset) ->
          Dns.Rr_map.Txt_set.iter (fun txt ->
@@ -148,20 +147,20 @@ let setup_log =
   Term.(const _setup_log $ Fmt_cli.style_renderer ~docs:sdocs ()
         $ Logs_cli.level ~docs:sdocs ())
 
-let parse_ns : (Lwt_unix.inet_addr * int) Arg.conv =
+let parse_ns : Ipaddr.t Arg.conv =
   ( fun ns ->
-      try match String.split_on_char ':' ns with
-      | [ ns ] -> `Ok (Unix.inet_addr_of_string ns, 53)
-      | [ ns ; port ] -> `Ok (Unix.inet_addr_of_string ns, int_of_string port)
-      | _ -> `Error "bad name server"
-      with
-      | _ -> `Error "NS must be an IPv4 address"),
-  ( fun ppf (ns, port) ->
-      Fmt.pf ppf "%s:%d" (Unix.string_of_inet_addr ns) port )
+      match Ipaddr.of_string ns with
+      | Ok ip -> `Ok ip
+      | Error (`Msg m) -> `Error ("bad name server: " ^ m)),
+  Ipaddr.pp
 
 let arg_ns : 'a Term.t =
   let doc = "IP of nameserver to use" in
   Arg.(value & opt (some parse_ns) None & info ~docv:"NS-IP" ~doc ["ns"])
+
+let arg_port : 'a Term.t =
+  let doc = "Port of nameserver" in
+  Arg.(value & opt int 53 & info ~docv:"NS-PORT" ~doc ["ns-port"])
 
 let arg_udp =
   let doc = "Connect via UDP to resolver" in
@@ -190,7 +189,7 @@ let cmd_a : unit Term.t * Term.info =
   let man = [
     `P {| Output mimics that of $(b,dig A )$(i,DOMAIN)|}
   ] in
-  Term.(term_result (const do_a $ arg_ns $ arg_udp $ arg_domains $ setup_log)),
+  Term.(term_result (const do_a $ arg_ns $ arg_port $ arg_udp $ arg_domains $ setup_log)),
   Term.info "a" ~version:(Manpage.escape "%%VERSION%%") ~man ~doc ~sdocs
 
 let cmd_aaaa : unit Term.t * Term.info =
@@ -198,7 +197,7 @@ let cmd_aaaa : unit Term.t * Term.info =
   let man = [
     `P {| Output mimics that of $(b,dig AAAA )$(i,DOMAIN)|}
   ] in
-  Term.(term_result (const do_aaaa $ arg_ns $ arg_udp $ arg_domains $ setup_log)),
+  Term.(term_result (const do_aaaa $ arg_ns $ arg_port $ arg_udp $ arg_domains $ setup_log)),
   Term.info "aaaa" ~version:(Manpage.escape "%%VERSION%%") ~man ~doc ~sdocs
 
 let cmd_mx : unit Term.t * Term.info =
@@ -206,7 +205,7 @@ let cmd_mx : unit Term.t * Term.info =
   let man = [
     `P {| Output mimics that of $(b,dig MX )$(i,DOMAIN)|}
   ] in
-  Term.(term_result (const do_mx $ arg_ns $ arg_udp $ arg_domains $ setup_log)),
+  Term.(term_result (const do_mx $ arg_ns $ arg_port $ arg_udp $ arg_domains $ setup_log)),
   Term.info "mx" ~version:(Manpage.escape "%%VERSION%%") ~man ~doc ~sdocs
 
 let cmd_tlsa : unit Term.t * Term.info =
@@ -228,7 +227,7 @@ let cmd_tlsa : unit Term.t * Term.info =
     `P {| $(b,_993._tcp) (IMAP) |} ;
     `S Manpage.s_options ;
   ] in
-  Term.(term_result (const do_tlsa $ arg_ns $ arg_udp $ arg_domains $ setup_log)),
+  Term.(term_result (const do_tlsa $ arg_ns $ arg_port $ arg_udp $ arg_domains $ setup_log)),
   Term.info "tlsa" ~version:(Manpage.escape "%%VERSION%%") ~man ~doc ~sdocs
 
 let cmd_txt : unit Term.t * Term.info =
@@ -240,7 +239,7 @@ let cmd_txt : unit Term.t * Term.info =
           It would be nice to mirror `dig` output here.|} ;
     `S Manpage.s_options ;
   ] in
-  Term.(term_result (const do_txt $ arg_ns $ arg_udp $ arg_domains $ setup_log)),
+  Term.(term_result (const do_txt $ arg_ns $ arg_port $ arg_udp $ arg_domains $ setup_log)),
   Term.info "txt" ~version:(Manpage.escape "%%VERSION%%") ~man ~doc ~sdocs
 
 let cmd_any : unit Term.t * Term.info =
@@ -267,7 +266,7 @@ let cmd_dkim : unit Term.t * Term.info =
        |} ;
     `S Manpage.s_options ;
   ] in
-  Term.(term_result (const do_dkim $ arg_ns $ arg_udp $ arg_selector
+  Term.(term_result (const do_dkim $ arg_ns $ arg_port $ arg_udp $ arg_selector
                      $ arg_domains $ setup_log)),
   Term.info "dkim" ~version:(Manpage.escape "%%VERSION%%") ~man ~doc ~sdocs
 

--- a/app/onotify.ml
+++ b/app/onotify.ml
@@ -23,7 +23,7 @@ let jump _ serverip port zone key serial =
   Mirage_crypto_rng_unix.initialize ();
   let now = Ptime_clock.now () in
   Logs.app (fun m -> m "notifying to %a:%d zone %a serial %lu"
-               Ipaddr.V4.pp serverip port Domain_name.pp zone serial) ;
+               Ipaddr.pp serverip port Domain_name.pp zone serial) ;
   match notify zone serial key now with
   | Error s -> Error (`Msg (Fmt.strf "signing %a" Dns_tsig.pp_s s))
   | Ok (request, data, mac) ->

--- a/app/oupdate.ml
+++ b/app/oupdate.ml
@@ -21,7 +21,7 @@ let jump _ serverip port (keyname, zone, dnskey) hostname ip_address =
   Mirage_crypto_rng_unix.initialize ();
   let now = Ptime_clock.now () in
   Logs.app (fun m -> m "updating to %a:%d zone %a A 600 %a %a"
-               Ipaddr.V4.pp serverip port
+               Ipaddr.pp serverip port
                Domain_name.pp zone
                Domain_name.pp hostname
                Ipaddr.V4.pp ip_address) ;
@@ -69,9 +69,17 @@ let hostname =
   let doc = "Hostname to modify" in
   Arg.(required & pos 2 (some Dns_cli.domain_name_c) None & info [] ~doc ~docv:"HOSTNAME")
 
+let ipv4_c : Ipaddr.V4.t Arg.converter =
+  let parse s =
+    match Ipaddr.V4.of_string s with
+    | Ok ip -> `Ok ip
+    | Error (`Msg m) -> `Error ("failed to parse IP address: " ^ m)
+  in
+  parse, Ipaddr.V4.pp
+
 let ip_address =
   let doc = "New IP address" in
-  Arg.(required & pos 3 (some Dns_cli.ip_c) None & info [] ~doc ~docv:"IP")
+  Arg.(required & pos 3 (some ipv4_c) None & info [] ~doc ~docv:"IP")
 
 let cmd =
   Term.(term_result (const jump $ Dns_cli.setup_log $ serverip $ port $ key $ hostname $ ip_address)),

--- a/certify/dns_certify.ml
+++ b/certify/dns_certify.ml
@@ -139,7 +139,7 @@ let cert_matches_csr ?until now csr cert =
   and (st, en) = X509.Certificate.validity cert
   in
   let valid = Ptime.is_later ~than:st now && Ptime.is_later ~than:until en in
-  if not (Cstruct.equal (X509.Public_key.id cert_key) (X509.Public_key.id csr_key)) then begin
+  if not (Cstruct.equal (X509.Public_key.fingerprint cert_key) (X509.Public_key.fingerprint csr_key)) then begin
     Log.info (fun m -> m "public key of CSR and certificate %a do not match"
                  X509.Certificate.pp cert);
     false
@@ -205,3 +205,28 @@ let query rng now host csr =
         | Error e -> Error (`Bad_reply (e, reply))
     in
     Ok (out, react)
+
+let generate ?key_seed ?(bits = 4096) ?key_data key_type =
+  let g, print =
+    match key_seed with
+    | None -> None, true
+    | Some seed ->
+      let seed = Cstruct.of_string seed in
+      Some Mirage_crypto_rng.(create ~seed (module Fortuna)), false
+  in
+  let rng c = match key_data with
+    | None -> Mirage_crypto_rng.generate ?g c
+    | Some s -> Cstruct.of_string s
+  in
+  let key =
+    match key_type with
+    | `RSA -> `RSA (Mirage_crypto_pk.Rsa.generate ?g ~bits ())
+    | `ED25519 -> `ED25519 (fst (Mirage_crypto_ec.Ed25519.generate ~rng))
+    | `P256 -> `P256 (fst (Mirage_crypto_ec.P256.Dsa.generate ~rng))
+    | `P384 -> `P384 (fst (Mirage_crypto_ec.P384.Dsa.generate ~rng))
+    | `P521 -> `P521 (fst (Mirage_crypto_ec.P521.Dsa.generate ~rng))
+  in
+  (if print then
+     let pem = X509.Private_key.encode_pem key in
+     Log.info (fun m -> m "using private key@.%s" (Cstruct.to_string pem)));
+  key

--- a/certify/dns_certify.mli
+++ b/certify/dns_certify.mli
@@ -91,3 +91,10 @@ val query : (int -> Cstruct.t) -> Ptime.t -> [ `host ] Domain_name.t ->
 (** [query rng now csr] is a [buffer] with a DNS TLSA query for the name of
    [csr], and a function that decodes a given answer, either returning a X.509
    certificate valid [now] and matching [csr], and a CA chain, or an error. *)
+
+val generate : ?key_seed:string -> ?bits:int -> ?key_data:string ->
+  [ `RSA | `ED25519 | `P256 | `P384 | `P521 ] -> X509.Private_key.t
+(** [generate ~key_seed ~bits ~key_data key_type] generates a private key from
+    [key_seed] of the provided [key_type]. If no [key_seed] is provided, random
+    data is used and the PEM-encoded private key is logged. If [key_type] is a
+    EC key and [key_data] is provided, this is used as private key. *)

--- a/certify/dune
+++ b/certify/dune
@@ -2,4 +2,4 @@
  (name dns_certify)
  (public_name dns-certify)
  (wrapped false)
- (libraries dns dns-tsig x509 randomconv logs))
+ (libraries dns dns-tsig x509 randomconv logs mirage-crypto-rng mirage-crypto-ec mirage-crypto-pk))

--- a/client/dns_client.ml
+++ b/client/dns_client.ml
@@ -136,7 +136,7 @@ module Pure = struct
 end
 
 (* Anycast address of uncensoreddns.org *)
-let default_resolver = "91.239.100.100"
+let default_resolver = "91.239.100.100", "2001:67c:28a4::"
 
 module type S = sig
   type context

--- a/client/dns_client.mli
+++ b/client/dns_client.mli
@@ -4,10 +4,10 @@
          better solution presents itself.
 *)
 
-val default_resolver : string
-(** [default_resolver] is the IPv4 address in dotted-decimal form of the default
-    resolver. Currently it is the IP address of the UncensoredDNS.org anycast
-    service. *)
+val default_resolver : string * string
+(** [default_resolver] is a pair of IPv4 and IPv6 address in dotted-decimal
+    (/hexadecimal) form of the default resolver. Currently it is the IP address
+    of the UncensoredDNS.org anycast service. *)
 
 module type S = sig
   type context

--- a/dns-certify.opam
+++ b/dns-certify.opam
@@ -28,7 +28,7 @@ depends: [
 ]
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/dns-certify.opam
+++ b/dns-certify.opam
@@ -15,13 +15,14 @@ depends: [
   "dns-mirage" {= version}
   "randomconv" {>= "0.1.2"}
   "duration" {>= "0.1.2"}
-  "x509" {>= "0.10.0"}
+  "x509" {>= "0.12.0"}
   "lwt" {>= "4.2.1"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-stack" {>= "2.2.0"}
   "logs"
+  "mirage-crypto-ec"
   "mirage-crypto-pk" {>= "0.8.0"}
   "mirage-crypto-rng" {>= "0.8.0"}
 ]

--- a/dns-cli.opam
+++ b/dns-cli.opam
@@ -35,7 +35,7 @@ depends: [
 ]
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/dns-client.opam
+++ b/dns-client.opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
 license: "BSD-2-Clause"
 
 build: [
-  [ "dune" "subst"] {pinned}
+  [ "dune" "subst"] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
   [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
 ]

--- a/dns-mirage.opam
+++ b/dns-mirage.opam
@@ -17,7 +17,7 @@ depends: [
 ]
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/dns-resolver.opam
+++ b/dns-resolver.opam
@@ -25,7 +25,7 @@ depends: [
 ]
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/dns-server.opam
+++ b/dns-server.opam
@@ -26,7 +26,7 @@ depends: [
 ]
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/dns-stub.opam
+++ b/dns-stub.opam
@@ -27,7 +27,7 @@ depends: [
 ]
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/dns-tsig.opam
+++ b/dns-tsig.opam
@@ -17,7 +17,7 @@ depends: [
 ]
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/dns.opam
+++ b/dns.opam
@@ -21,7 +21,7 @@ depends: [
   "metrics"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/lwt/client/dns_client_lwt.mli
+++ b/lwt/client/dns_client_lwt.mli
@@ -11,7 +11,7 @@
 (** A flow module based on non-blocking I/O on top of the
     Lwt_unix socket API. *)
 module Transport : Dns_client.S
-   with type io_addr = Lwt_unix.inet_addr * int
+   with type io_addr = Ipaddr.t * int
    and type +'a io = 'a Lwt.t
    and type stack = unit
 

--- a/mirage/certify/dns_certify_mirage.mli
+++ b/mirage/certify/dns_certify_mirage.mli
@@ -3,18 +3,18 @@ module Make (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S) 
 
   val retrieve_certificate :
     S.t -> dns_key:string -> hostname:[ `host ] Domain_name.t ->
-    ?additional_hostnames:[ `raw ] Domain_name.t list -> ?key_seed:string ->
-    S.TCP.ipaddr -> int ->
-    (X509.Certificate.t list * Mirage_crypto_pk.Rsa.priv,
-     [ `Msg of string ]) result Lwt.t
-  (** [retrieve_certificate stack ~dns_key ~hostname ~key_seed server_ip port]
-     generates a RSA private key (using the [key_seed]), a certificate
-     signing request for the given [hostname] and [additional_hostnames], and
-     sends [server_ip] an nsupdate (DNS-TSIG with [dns_key]) with the csr as
-     TLSA record, awaiting for a matching certificate as TLSA record. Requires a
-     service that interacts with let's encrypt to transform the CSR into a
-     signed certificate. If something fails, an exception (via [Lwt.fail]) is
-     raised. This is meant for unikernels that require a valid TLS certificate
-     before they can start their service (i.e. most web servers, mail
-     servers). *)
+    ?additional_hostnames:[ `raw ] Domain_name.t list ->
+    ?key_type:[ `RSA | `ED25519 | `P256 | `P384 | `P521 ] ->
+    ?key_data:string -> ?key_seed:string -> ?bits:int -> S.TCP.ipaddr -> int ->
+    (X509.Certificate.t list * X509.Private_key.t, [ `Msg of string ]) result Lwt.t
+  (** [retrieve_certificate stack ~dns_key ~hostname ~key_type ~key_data ~key_seed ~bits server_ip port]
+      generates a private key (using [key_type], [key_data], [key_seed], and
+      [bits]), a certificate signing request for the given [hostname] and
+      [additional_hostnames], and sends [server_ip] an nsupdate (DNS-TSIG with
+      [dns_key]) with the csr as TLSA record, awaiting for a matching
+      certificate as TLSA record. Requires a service that interacts with let's
+      encrypt to transform the CSR into a signed certificate. If something
+      fails, an exception (via [Lwt.fail]) is raised. This is meant for
+      unikernels that require a valid TLS certificate before they can start
+      their service (i.e. most web servers, mail servers). *)
 end

--- a/mirage/client/dns_client_mirage.ml
+++ b/mirage/client/dns_client_mirage.ml
@@ -21,7 +21,7 @@ module Make (R : Mirage_random.S) (T : Mirage_time.S) (C : Mirage_clock.MCLOCK) 
     type context = { t : t ; flow : S.TCP.flow ; timeout_ns : int64 ref }
 
     let create
-        ?(nameserver = `TCP, (Ipaddr.V4 (Ipaddr.V4.of_string_exn Dns_client.default_resolver), 53))
+        ?(nameserver = `TCP, (Ipaddr.V4 (Ipaddr.V4.of_string_exn (fst Dns_client.default_resolver)), 53))
         ~timeout
         stack =
       { nameserver ; timeout_ns = timeout ; stack }

--- a/mirage/stub/dns_stub_mirage.ml
+++ b/mirage/stub/dns_stub_mirage.ml
@@ -86,7 +86,7 @@ module Make (R : Mirage_random.S) (T : Mirage_time.S) (P : Mirage_clock.PCLOCK) 
       type context = { t : t ; timeout_ns : int64 ref ; mutable id : int }
 
       let create
-          ?(nameserver = `TCP, (Ipaddr.V4 (Ipaddr.V4.of_string_exn Dns_client.default_resolver), 53))
+          ?(nameserver = `TCP, (Ipaddr.V4 (Ipaddr.V4.of_string_exn (fst Dns_client.default_resolver)), 53))
           ~timeout
           stack =
         { nameserver ; timeout_ns = timeout ; stack ; flow = None ; requests = IM.empty }

--- a/unix/client/dns_client_unix.mli
+++ b/unix/client/dns_client_unix.mli
@@ -10,7 +10,7 @@
     TODO: Implement the connect timeout.
 *)
 module Transport : Dns_client.S
-  with type io_addr = Unix.inet_addr * int
+  with type io_addr = Ipaddr.t * int
    and type stack = unit
    and type +'a io = 'a
 


### PR DESCRIPTION
(a) dns-certify supports more key types than RSA
(b) IPv6 support in dns-client.unix & dns-client.lwt
(c) further tweaks