### PR TITLE
revise cache

### DIFF
--- a/cache/dns_cache.ml
+++ b/cache/dns_cache.ml
@@ -91,11 +91,10 @@ end
 
 module Key = struct
   type t = [ `raw ] Domain_name.t
-  let equal a b = Domain_name.equal a b
-  let hash r v = Hashtbl.seeded_hash r v
+  let compare = Domain_name.compare
 end
 
-module LRU = Lru.M.MakeSeeded(Key)(Entry)
+module LRU = Lru.F.Make(Key)(Entry)
 
 type t = LRU.t
 
@@ -110,7 +109,7 @@ let metrics =
   let metrics = Dns.counter_metrics ~f "dns-cache" in
   (fun x -> Metrics.add metrics (fun x -> x) (fun d -> d x))
 
-let empty size = LRU.create ~random:true size
+let empty = LRU.empty
 
 let size = LRU.size
 
@@ -162,12 +161,13 @@ let find cache name query_type =
 
 let insert cache ?map ts name query_type rank entry =
   let meta = ts, rank in
-  (match entry with
-   | `No_domain (name', soa) -> LRU.add name (No_domain (meta, name', soa)) cache
-   | `Entry _ | `No_data _ | `Serv_fail _ ->
-     let map = match map with None -> RRMap.empty | Some x -> x in
-     let map' = RRMap.add (K query_type) (meta, Entry.of_entry entry) map in
-     LRU.add name (Rr_map map') cache);
+  let cache = match entry with
+    | `No_domain (name', soa) -> LRU.add name (No_domain (meta, name', soa)) cache
+    | `Entry _ | `No_data _ | `Serv_fail _ ->
+      let map = match map with None -> RRMap.empty | Some x -> x in
+      let map' = RRMap.add (K query_type) (meta, Entry.of_entry entry) map in
+      LRU.add name (Rr_map map') cache
+  in
   (* Make sure we are within memory bounds *)
   LRU.trim cache
 
@@ -179,11 +179,11 @@ let update_ttl entry ~created ~now =
 let get cache ts name query_type =
   metrics `Lookup;
   match snd (find cache name query_type) with
-  | Error e -> metrics `Miss; Error e
+  | Error e -> metrics `Miss; cache, Error e
   | Ok ((created, _), entry) ->
     match update_ttl entry ~created ~now:ts with
-    | Ok entry' -> metrics `Hit; LRU.promote name cache; Ok entry'
-    | Error e -> metrics `Drop; Error e
+    | Ok entry' -> metrics `Hit; LRU.promote name cache, Ok entry'
+    | Error e -> metrics `Drop; cache, Error e
 
 (* XXX: we may want to define a minimum as well (5 minutes? 30 minutes?
    use SOA expiry?) MS used to use 24 hours in internet explorer
@@ -230,5 +230,5 @@ let set cache ts name query_type rank entry  =
     Logs.debug (fun m -> m "set: %a found rank %a insert rank %a: %d"
                    pp_query (name, `K (K query_type)) pp_rank rank' pp_rank rank (compare_rank rank' rank));
     match compare_rank rank' rank with
-    | 1 -> ()
+    | 1 -> cache
     | _ -> metrics `Insert; cache' map

--- a/cache/dns_cache.mli
+++ b/cache/dns_cache.mli
@@ -1,6 +1,17 @@
+(** DNS cache - a least recently used cache of DNS responses
+
+    This data structure allows to insert and retrieve entries into a least
+    recently used data structure. An [`Entry] weights the cardinality of the
+    resource record map, all other entries have a weight of 1.
+
+    The time to live is preserved, and when it is exceeded the entry is no
+    longer returned.
+*)
+
 (* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 open Dns
 
+(** The variant of the rank in the cache. *)
 type rank =
   | ZoneFile
   | ZoneTransfer
@@ -11,19 +22,29 @@ type rank =
   | Additional
 
 val pp_rank : rank Fmt.t
+(** [pp_rank ppf rank] pretty-prints the [rank] on [ppf]. *)
 
 val compare_rank : rank -> rank -> int
+(** [compare_rank a b] compares the ranks [a] with [b]. *)
 
+(** The type of a DNS cache. *)
 type t
 
 val empty : int -> t
+(** [empty maximum_size] is an empty DNS cache with the maximum size as
+    capacity. *)
 
 val size : t -> int
+(** [size cache] is the number of bindings currently in the [cache]. *)
 
 val capacity : t -> int
+(** [capacity cache] is the used weight. *)
 
 val pp : t Fmt.t
+(** [pp ppf t] pretty prints the cache [t] on [ppf]. *)
 
+(** The polymorphic variant of an entry: a resource record, or no data,
+    no domain, or a server failure. *)
 type entry = [
   | `Entry of Rr_map.b
   | `No_data of [ `raw ] Domain_name.t * Soa.t
@@ -32,11 +53,22 @@ type entry = [
 ]
 
 val pp_entry : entry Fmt.t
+(** [pp_entry ppf entry] pretty-prints [entry] on [ppf]. *)
 
 val get : t -> int64 -> [ `raw ] Domain_name.t -> 'a Rr_map.key ->
   t * (entry, [ `Cache_miss | `Cache_drop ]) result
-(** [get lru_cache timestamp request_type name] *)
+(** [get cache timestamp type name] retrieves the query [type, name] from the
+    [cache] using [timestamp]. If the time to live is exceeded, a [`Cache_drop]
+    is returned. If there is no entry in the cache, a [`Cache_miss] is
+    returned. *)
+
+val get_or_cname : t -> int64 -> [ `raw ] Domain_name.t -> 'a Rr_map.key ->
+  t * (entry, [ `Cache_miss | `Cache_drop ]) result
+(** [get_or_cname cache timestamp type name] is the same as [get], but if a
+    [`Cache_miss] is encountered, a lookup for an alias (CNAME) is done. *)
 
 val set : t -> int64 -> [ `raw ] Domain_name.t -> 'a Rr_map.key -> rank ->
   entry -> t
-(** [set lru_cache timestamp request_type name rank value] *)
+(** [set cache timestamp type name rank value] attempts to insert
+    [type, name, value] into the [cache] using the [timestamp] and [rank]. If
+    an entry already exists with a higher [rank], the [cache] is unchanged. *)

--- a/cache/dns_cache.mli
+++ b/cache/dns_cache.mli
@@ -34,9 +34,9 @@ type entry = [
 val pp_entry : entry Fmt.t
 
 val get : t -> int64 -> [ `raw ] Domain_name.t -> 'a Rr_map.key ->
-  (entry, [ `Cache_miss | `Cache_drop ]) result
+  t * (entry, [ `Cache_miss | `Cache_drop ]) result
 (** [get lru_cache timestamp request_type name] *)
 
 val set : t -> int64 -> [ `raw ] Domain_name.t -> 'a Rr_map.key -> rank ->
-  entry -> unit
+  entry -> t
 (** [set lru_cache timestamp request_type name rank value] *)

--- a/resolver/dns_resolver_cache.ml
+++ b/resolver/dns_resolver_cache.ml
@@ -2,292 +2,18 @@
 
 open Dns
 
-type rank =
-  | ZoneFile
-  | ZoneTransfer
-  | AuthoritativeAnswer
-  | AuthoritativeAuthority
-  | ZoneGlue
-  | NonAuthoritativeAnswer
-  | Additional
+type t = Dns_cache.t
 
-let compare_rank a b = match a, b with
-  | ZoneFile, ZoneFile -> 0
-  | ZoneFile, _ -> 1
-  | _, ZoneFile -> -1
-  | ZoneTransfer, ZoneTransfer -> 0
-  | ZoneTransfer, _ -> 1
-  | _, ZoneTransfer -> -1
-  | AuthoritativeAnswer, AuthoritativeAnswer -> 0
-  | AuthoritativeAnswer, _ -> 1
-  | _, AuthoritativeAnswer -> -1
-  | AuthoritativeAuthority, AuthoritativeAuthority -> 0
-  | AuthoritativeAuthority, _ -> 1
-  | _, AuthoritativeAuthority -> -1
-  | ZoneGlue, ZoneGlue -> 0
-  | ZoneGlue, _ -> 1
-  | _, ZoneGlue -> -1
-  | NonAuthoritativeAnswer, NonAuthoritativeAnswer -> 0
-  | NonAuthoritativeAnswer, _ -> 1
-  | _, NonAuthoritativeAnswer -> -1
-  | Additional, Additional -> 0
-
-let pp_rank ppf r = Fmt.string ppf (match r with
-    | ZoneFile -> "zone file data"
-    | ZoneTransfer -> "zone transfer data"
-    | AuthoritativeAnswer -> "authoritative answer data"
-    | AuthoritativeAuthority -> "authoritative authority data"
-    | ZoneGlue -> "zone file glue"
-    | NonAuthoritativeAnswer -> "non-authoritative answer"
-    | Additional -> "additional data")
-
-module RRMap = Map.Make(struct
-    type t = Rr_map.k
-    let compare = Rr_map.comparek
-  end)
-
-module V = struct
-  type meta = int64 * rank
-  let pp_meta ppf (crea, rank) =
-    Fmt.pf ppf "%a created %Lu" pp_rank rank crea
-
-  type rr_map_entry =
-    | Entry of Rr_map.b
-    | No_data of [ `raw ] Domain_name.t * Soa.t
-    | Serv_fail of [ `raw ] Domain_name.t * Soa.t
-  let pp_map_entry ppf entry = match entry with
-    | Entry b -> Fmt.pf ppf "entry %a" Rr_map.pp_b b
-    | No_data (name, soa) -> Fmt.pf ppf "no data %a SOA %a" Domain_name.pp name Soa.pp soa
-    | Serv_fail (name, soa) -> Fmt.pf ppf "server fail %a SOA %a" Domain_name.pp name Soa.pp soa
-  let to_res = function
-    | Entry b -> `Entry b
-    | No_data (name, soa) -> `No_data (name, soa)
-    | Serv_fail (name, soa) -> `Serv_fail (name, soa)
-  let of_res = function
-    | `Entry b -> Entry b
-    | `No_data (name, soa) -> No_data (name, soa)
-    | `Serv_fail (name, soa) -> Serv_fail (name, soa)
-    | _ -> assert false
-
-  type t =
-    | Alias of meta * int32 * [ `raw ] Domain_name.t
-    | No_domain of meta * [ `raw ] Domain_name.t * Soa.t
-    | Rr_map of (meta * rr_map_entry) RRMap.t
-
-  let weight = function
-    | Alias _ | No_domain _ -> 1
-    | Rr_map tm -> RRMap.cardinal tm
-
-  let pp_entry ppf (meta, entry) = Fmt.pf ppf "e (%a) %a" pp_meta meta pp_map_entry entry
-
-  let pp ppf = function
-    | Alias (meta, ttl, a) ->
-      Fmt.pf ppf "alias (%a) TTL %lu %a" pp_meta meta ttl Domain_name.pp a
-    | No_domain (meta, name, soa) ->
-      Fmt.pf ppf "no domain (%a) %a SOA %a" pp_meta meta Domain_name.pp name Soa.pp soa
-    | Rr_map rr ->
-      Fmt.pf ppf "entries: %a"
-        Fmt.(list ~sep:(unit ";@,") (pair Rr_map.ppk pp_entry))
-        (RRMap.bindings rr)
-end
-
-module D = struct
-  type t = [ `raw ] Domain_name.t
-  let compare = Domain_name.compare
-end
-
-module LRU = Lru.F.Make(D)(V)
-
-type t = LRU.t
-
-let pp_question ppf (name, typ) =
-  Fmt.pf ppf "%a (%a)" Domain_name.pp name Packet.Question.pp_qtype typ
-
-type stats = {
-  hit : int ;
-  miss : int ;
-  drop : int ;
-  insert : int ;
-}
-
-let s = ref { hit = 0 ; miss = 0 ; drop = 0 ; insert = 0 }
-
-let pp_stats pf s =
-  Fmt.pf pf "cache: %d hits %d misses %d drops %d inserts" s.hit s.miss s.drop s.insert
-
-let stats () = !s
-
-(* this could need a `Timeout error result *)
-
-let empty = LRU.empty
-
-let size = LRU.size
-
-let capacity = LRU.capacity
-
-let pp = LRU.pp Fmt.(pair ~sep:(unit ": ") Domain_name.pp V.pp)
+let empty = Dns_cache.empty
 
 module N = Domain_name.Set
 
-let update_ttl ~created ~now ttl =
-  Int32.sub ttl (Int32.of_int (Duration.to_sec (Int64.sub now created)))
-
-type res = [
-  | `Alias of int32 * [ `raw ] Domain_name.t
-  | `Entry of Rr_map.b
-  | `No_data of [ `raw ] Domain_name.t * Soa.t
-  | `No_domain of [ `raw ] Domain_name.t * Soa.t
-  | `Serv_fail of [ `raw ] Domain_name.t * Soa.t
-]
-
-let pp_res ppf res =
-  let pp_ns ppf (name, soa) = Fmt.pf ppf "%a SOA %a" Domain_name.pp name Soa.pp soa in
-  match res with
-  | `Alias (ttl, name) -> Fmt.pf ppf "alias TTL %lu %a" ttl Domain_name.pp name
-  | `Entry b -> Fmt.pf ppf "entry %a" Rr_map.pp_b b
-  | `No_data ns -> Fmt.(prefix (unit "no data ") pp_ns) ppf ns
-  | `No_domain ns -> Fmt.(prefix (unit "no domain ") pp_ns) ppf ns
-  | `Serv_fail ns -> Fmt.(prefix (unit "serv fail ") pp_ns) ppf ns
-
-let get_ttl = function
-  | `Alias (ttl, _) -> ttl
-  | `Entry b -> Rr_map.get_ttl b
-  | `No_data (_, soa) -> soa.Soa.minimum
-  | `No_domain (_, soa) -> soa.Soa.minimum
-  | `Serv_fail (_, soa) -> soa.Soa.minimum
-
-let with_ttl ttl = function
-  | `Alias (_, name) -> `Alias (ttl, name)
-  | `Entry b -> `Entry (Rr_map.with_ttl b ttl)
-  | `No_data (name, soa) -> `No_data (name, { soa with Soa.minimum = ttl })
-  | `No_domain (name, soa) -> `No_domain (name, { soa with Soa.minimum = ttl })
-  | `Serv_fail (name, soa) -> `Serv_fail (name, { soa with Soa.minimum = ttl })
-
-let find_lru t name typ =
-  match LRU.find name t with
-  | None -> None, Error `Cache_miss
-  | Some Alias (meta, ttl, alias) -> None, Ok (meta, `Alias (ttl, alias))
-  | Some No_domain (meta, name, soa) -> None, Ok (meta, `No_domain (name, soa))
-  | Some Rr_map tm ->
-    Some tm,
-    try
-      let meta, entry = RRMap.find (K typ) tm in
-      Ok (meta, V.to_res entry)
-    with
-    | Not_found -> Error `Cache_miss
-
-let insert_lru t ?map name typ created rank res =
-  s := { !s with insert = succ !s.insert };
-  let meta = created, rank in
-  let t' = match res with
-    | `No_domain (name', soa) -> LRU.add name (No_domain (meta, name', soa)) t
-    | `Alias (ttl, alias) -> LRU.add name (Alias (meta, ttl, alias)) t
-    | `Entry _ | `No_data _ | `Serv_fail _ ->
-      let map = match map with None -> RRMap.empty | Some x -> x in
-      let map' = RRMap.add (K typ) (meta, V.of_res res) map in
-      LRU.add name (Rr_map map') t
-  in
-  LRU.trim t'
-
-let update_ttl_res e ~created ~now =
-  let ttl = get_ttl e in
-  let updated_ttl = update_ttl ~created ~now ttl in
-  if updated_ttl < 0l then Error `Cache_drop else Ok (with_ttl updated_ttl e)
-
-let cached t now typ nam =
-  match snd (find_lru t nam typ) with
-  | Error e ->
-    s := { !s with miss = succ !s.miss };
-    Error e
-  | Ok ((created, _), e) ->
-    match update_ttl_res e ~created ~now with
-    | Ok e' ->
-      s := { !s with hit = succ !s.hit };
-      Ok (e', LRU.promote nam t)
-    | Error e ->
-      s := { !s with drop = succ !s.drop };
-      Error e
-
-let cached_any t now nam =
-  match find_lru t nam A with
-  | Some rrmap, _ ->
-    let rrs =
-      RRMap.fold (fun _typ ((created, _), e) acc ->
-          match update_ttl_res (V.to_res e) ~created ~now with
-          | Ok (`Entry Rr_map.(B (k, v))) -> Rr_map.add k v acc
-          | Ok (`Alias a) -> Rr_map.add Cname a acc
-          | Ok (`No_data _ | `Serv_fail _ | `No_domain _) -> acc
-          | Error _ -> acc)
-        rrmap Rr_map.empty
-    in
-    if Rr_map.is_empty rrs then begin
-      s := { !s with miss = succ !s.miss };
-      Error `Cache_miss
-    end else begin
-      s := { !s with hit = succ !s.hit };
-      Ok (`Entries rrs, LRU.promote nam t)
-    end
-  | _, Error e ->
-    s := { !s with miss = succ !s.miss };
-    Error e
-  | _, Ok ((created, _), e) ->
-    let ttl = get_ttl e in
-    let updated_ttl = update_ttl ~created ~now ttl in
-    if updated_ttl < 0l then begin
-      s := { !s with drop = succ !s.drop };
-      Error `Cache_drop
-    end else begin
-      s := { !s with hit = succ !s.hit };
-      Ok (with_ttl updated_ttl e, LRU.promote nam t)
-    end
-
-
 let pp_err ppf = function
-  | `Cache_drop -> Fmt.string ppf "cache drop"
   | `Cache_miss -> Fmt.string ppf "cache miss"
+  | `Cache_drop -> Fmt.string ppf "cache drop"
 
-(* according to RFC1035, section 7.3, a TTL of a week is a good maximum value! *)
-(* XXX: we may want to define a minimum as well (5 minutes? 30 minutes?
-   use SOA expiry?) MS used to use 24 hours in internet explorer
-
-from RFC1034 on this topic:
-The idea is that if cached data is known to come from a particular zone,
-and if an authoritative copy of the zone's SOA is obtained, and if the
-zone's SERIAL has not changed since the data was cached, then the TTL of
-the cached data can be reset to the zone MINIMUM value if it is smaller.
-This usage is mentioned for planning purposes only, and is not
-recommended as yet.
-
-and 2308, Sec 4:
-   Despite being the original defined meaning, the first of these, the
-   minimum TTL value of all RRs in a zone, has never in practice been
-   used and is hereby deprecated.
-
-and 1035 6.2:
-   The MINIMUM value in the SOA should be used to set a floor on the TTL of data
-   distributed from a zone.  This floor function should be done when the data is
-   copied into a response.  This will allow future dynamic update protocols to
-   change the SOA MINIMUM field without ambiguous semantics.
-*)
-let week = Int32.of_int Duration.(to_sec (of_day 7))
-
-let smooth_ttl e =
-  let ttl = get_ttl e in
-  if ttl < week then e else with_ttl week e
-
-let maybe_insert typ nam ts rank e t =
-  let entry = smooth_ttl e in
-  match find_lru t nam typ with
-  | map, Error _ ->
-    Logs.debug (fun m -> m "maybe_insert: %a nothing found, adding: %a"
-                   pp_question (nam, `K (K typ)) pp_res entry);
-    insert_lru ?map t nam typ ts rank entry
-  | map, Ok ((_, rank'), entry) ->
-    Logs.debug (fun m -> m "maybe_insert: %a found rank %a insert rank %a: %d"
-                   pp_question (nam, `K (K typ)) pp_rank rank' pp_rank rank (compare_rank rank' rank));
-    match compare_rank rank' rank with
-    | 1 -> t
-    | _ -> insert_lru ?map t nam typ ts rank entry
+let pp_question ppf (name, typ) =
+  Fmt.pf ppf "%a (%a)" Domain_name.pp name Packet.Question.pp_qtype typ
 
 (*
 let resolve_ns t ts name =
@@ -385,11 +111,11 @@ let find_nearest_ns rng ts t name =
     | [ x ] -> Some x
     | xs -> Some (List.nth xs (Randomconv.int ~bound:(List.length xs) rng))
   in
-  let find_ns name = match cached t ts Ns name with
-    | Ok (`Entry Rr_map.(B (Ns, (_, names))), _) -> Domain_name.Host_set.elements names
+  let find_ns name = match snd (Dns_cache.get t ts name Ns) with
+    | Ok `Entry Rr_map.(B (Ns, (_, names))) -> Domain_name.Host_set.elements names
     | _ -> []
-  and find_a name = match cached t ts A name with
-    | Ok (`Entry Rr_map.(B (A, (_, ips))), _) -> Rr_map.Ipv4_set.elements ips
+  and find_a name = match snd (Dns_cache.get t ts name A) with
+    | Ok `Entry Rr_map.(B (A, (_, ips))) -> Rr_map.Ipv4_set.elements ips
     | _ -> []
   in
   let or_root f nam =
@@ -555,12 +281,13 @@ let to_map (name, soa) = Name_rr_map.singleton name Soa soa
 
 let follow_cname t ts typ ~name ttl ~alias =
   let rec follow t acc name =
-    match cached t ts typ name with
+    let t, r = Dns_cache.get t ts name typ in
+    match r with
     | Error _ ->
       Logs.debug (fun m -> m "follow_cname: cache miss, need to query %a"
                      Domain_name.pp name);
       `Query (name, t)
-    | Ok (`Alias (ttl, alias), t) ->
+    | Ok `Entry (Rr_map.B (Cname, (_, alias))) ->
       let acc' = Domain_name.Map.add name Rr_map.(singleton Cname (ttl, alias)) acc in
       if Domain_name.Map.mem alias acc then begin
         Logs.warn (fun m -> m "follow_cname: cycle detected") ;
@@ -570,17 +297,17 @@ let follow_cname t ts typ ~name ttl ~alias =
                        Domain_name.pp alias);
         follow t acc' alias
       end
-    | Ok (`Entry (Rr_map.B (k, v)), t) ->
+    | Ok `Entry (Rr_map.B (k, v)) ->
       let acc' = Domain_name.Map.add name Rr_map.(singleton k v) acc in
       Logs.debug (fun m -> m "follow_cname: entry found, returning");
       `Out (Rcode.NoError, acc', Name_rr_map.empty, t)
-    | Ok (`No_domain res, t) ->
+    | Ok `No_domain res ->
       Logs.debug (fun m -> m "follow_cname: nodom");
       `Out (Rcode.NXDomain, acc, to_map res, t)
-    | Ok (`No_data res, t) ->
+    | Ok `No_data res ->
       Logs.debug (fun m -> m "follow_cname: nodata");
       `Out (Rcode.NoError, acc, to_map res, t)
-    | Ok (`Serv_fail res, t) ->
+    | Ok `Serv_fail res ->
       Logs.debug (fun m -> m "follow_cname: servfail") ;
       `Out (Rcode.ServFail, acc, to_map res, t)
   in
@@ -614,33 +341,33 @@ let answer t ts name typ =
     in
     (flags, data, t)
   in
-  let r = match typ with
-    | `Any -> cached_any t ts name
-    | `K (Rr_map.K ty) -> cached t ts ty name
+  let t, r = match typ with
+    | `Any -> Dns_cache.get t ts name A (* TODO *)
+    | `K (Rr_map.K ty) -> Dns_cache.get t ts name ty
   in
   match r with
   | Error e ->
     Logs.warn (fun m -> m "error %a while looking up %a, query"
                   pp_err e pp_question (name, typ));
     `Query (name, t)
-  | Ok (`No_domain res, t) ->
+  | Ok `No_domain res ->
     Logs.debug (fun m -> m "no domain while looking up %a, query" pp_question (name, typ));
     `Packet (packet t false Rcode.NXDomain Domain_name.Map.empty (to_map res))
-  | Ok (`No_data res, t) ->
+  | Ok `No_data res ->
     Logs.debug (fun m -> m "no data while looking up %a" pp_question (name, typ));
     `Packet (packet t false Rcode.NoError Domain_name.Map.empty (to_map res))
-  | Ok (`Serv_fail res, t) ->
+  | Ok `Serv_fail res ->
     Logs.debug (fun m -> m "serv fail while looking up %a" pp_question (name, typ));
     `Packet (packet t false Rcode.ServFail Domain_name.Map.empty (to_map res))
-  | Ok (`Entry (Rr_map.B (k, v)), t) ->
+  | Ok `Entry (Rr_map.B (k, v)) ->
     Logs.debug (fun m -> m "entry while looking up %a" pp_question (name, typ));
     let data = Name_rr_map.singleton name k v in
     `Packet (packet t true Rcode.NoError data Domain_name.Map.empty)
-  | Ok (`Entries rr_map, t) ->
+(*  | Ok `Entries rr_map ->
     Logs.debug (fun m -> m "entries while looking up %a" pp_question (name, typ));
     let data = Domain_name.Map.singleton name rr_map in
-    `Packet (packet t true Rcode.NoError data Domain_name.Map.empty)
-  | Ok (`Alias (ttl, alias), t) ->
+    `Packet (packet t true Rcode.NoError data Domain_name.Map.empty) *)
+(*  | Ok (`Alias (ttl, alias), t) ->
     Logs.debug (fun m -> m "alias while looking up %a" pp_question (name, typ));
     match typ with
     | `Any ->
@@ -652,7 +379,7 @@ let answer t ts name typ =
     | `K (K ty) ->
       match follow_cname t ts ty ~name ttl ~alias with
       | `Out (rcode, an, au, t) -> `Packet (packet t true rcode an au)
-      | `Query (n, t) -> `Query (n, t)
+      | `Query (n, t) -> `Query (n, t) *)
 
 let handle_query t ~rng ts qname qtype =
   match answer t ts qname qtype with
@@ -669,6 +396,7 @@ let handle_query t ~rng ts qname qtype =
     let name, typ =
       if Domain_name.equal name' qname' then qname, qtype else name', `K typ
     in
-    Logs.debug (fun m -> m "resolve returned zone %a query %a, ip %a"
-                   Domain_name.pp zone pp_question (name, typ) Ipaddr.pp ip);
+    Logs.debug (fun m -> m "resolve returned zone %a query %a (%a), ip %a"
+                   Domain_name.pp zone Domain_name.pp name
+                   Packet.Question.pp_qtype typ Ipaddr.pp ip);
     `Query (zone, (name, typ), ip), t

--- a/resolver/dns_resolver_cache.mli
+++ b/resolver/dns_resolver_cache.mli
@@ -1,51 +1,11 @@
 (* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 open Dns
 
-type rank =
-  | ZoneFile
-  | ZoneTransfer
-  | AuthoritativeAnswer
-  | AuthoritativeAuthority
-  | ZoneGlue
-  | NonAuthoritativeAnswer
-  | Additional
-
-val pp_rank : rank Fmt.t
-
-val compare_rank : rank -> rank -> int
-
-type t
-
-type stats
-
-val pp_stats : stats Fmt.t
-
-val stats : unit -> stats
+type t = Dns_cache.t
 
 val empty : int -> t
 
-val size : t -> int
-
-val capacity : t -> int
-
-val pp : t Fmt.t
-
 val pp_question : ([ `raw ] Domain_name.t * Packet.Question.qtype) Fmt.t
-
-type res = [
-  | `Alias of int32 * [ `raw ] Domain_name.t
-  | `Entry of Rr_map.b
-  | `No_data of [ `raw ] Domain_name.t * Soa.t
-  | `No_domain of [ `raw ] Domain_name.t * Soa.t
-  | `Serv_fail of [ `raw ] Domain_name.t * Soa.t
-]
-
-val pp_res : res Fmt.t
-
-val cached : t -> int64 -> 'a Rr_map.key -> [ `raw ] Domain_name.t ->
-  (res * t, [ `Cache_miss | `Cache_drop ]) result
-
-val maybe_insert : 'a Rr_map.key -> [ `raw ] Domain_name.t -> int64 -> rank -> res -> t -> t
 
 val follow_cname : t -> int64 -> 'a Rr_map.key -> name:[ `raw ] Domain_name.t -> int32 ->
   alias:[ `raw ] Domain_name.t ->

--- a/resolver/dns_resolver_utils.mli
+++ b/resolver/dns_resolver_utils.mli
@@ -3,7 +3,7 @@
 open Dns
 
 val scrub : ?mode:[ `Recursive | `Stub ] -> [ `raw ] Domain_name.t -> Packet.Question.qtype -> Packet.t ->
-  ((Rr_map.k * [ `raw ] Domain_name.t * Dns_resolver_cache.rank * Dns_resolver_cache.res) list,
+  ((Rr_map.k * [ `raw ] Domain_name.t * Dns_cache.rank * Dns_cache.entry) list,
    Rcode.t) result
 (** [scrub ~mode bailiwick packet] returns a list of entries to-be-added to the
     cache. This respects only in-bailiwick resources records, and qualifies the

--- a/resolver/dune
+++ b/resolver/dune
@@ -2,4 +2,4 @@
  (name dns_resolver)
  (public_name dns-resolver)
  (wrapped false)
- (libraries dns dns-server lru duration randomconv))
+ (libraries dns dns.cache dns-server lru duration randomconv))

--- a/test/cache.ml
+++ b/test/cache.ml
@@ -49,17 +49,17 @@ let empty_cache () =
   let cache = Dns_cache.empty 100 in
   Alcotest.check cached_r "empty cache results in Cache_miss"
     (Error `Cache_miss)
-    (Dns_cache.get cache 0L (name "an-actual-website.com") A)
+    (snd (Dns_cache.get cache 0L (name "an-actual-website.com") A))
 
 let cache_a () =
   let cache = Dns_cache.empty 100 in
   let name = name "an-actual-website.com" in
   let a = Rr_map.(B (A, (250l, Ipv4_set.singleton (ip "1.2.3.4")))) in
-  Dns_cache.set cache 0L name A AuthoritativeAnswer (`Entry a);
+  let cache = Dns_cache.set cache 0L name A AuthoritativeAnswer (`Entry a) in
   Alcotest.check cached_r "cache with A results in res"
-    (Ok (`Entry a)) (Dns_cache.get cache 0L name A) ;
+    (Ok (`Entry a)) (snd (Dns_cache.get cache 0L name A)) ;
   Alcotest.check cached_r "cache with A results in CacheMiss"
-    (Error `Cache_miss) (Dns_cache.get cache 0L name Cname)
+    (Error `Cache_miss) (snd (Dns_cache.get cache 0L name Cname))
 
 let cache_nodata () =
   let cache = Dns_cache.empty 100 in
@@ -69,19 +69,19 @@ let cache_nodata () =
   let soa = invalid_soa name in
   let nodata = `No_data (subname, soa) in
   let a = Rr_map.(B (A, (250l, Ipv4_set.singleton (ip "1.2.3.4")))) in
-  Dns_cache.set cache 0L name A AuthoritativeAnswer (`Entry a);
-  Dns_cache.set cache 0L subname A AuthoritativeAnswer nodata;
+  let cache = Dns_cache.set cache 0L name A AuthoritativeAnswer (`Entry a) in
+  let cache = Dns_cache.set cache 0L subname A AuthoritativeAnswer nodata in
   Alcotest.check cached_r "cache with A nodata results in nodata"
-    (Ok nodata) (Dns_cache.get cache 0L subname A) ;
+    (Ok nodata) (snd (Dns_cache.get cache 0L subname A)) ;
   Alcotest.check cached_r "cache with A nodata results in cache miss for NS"
-    (Error `Cache_miss) (Dns_cache.get cache 0L subname Ns) ;
+    (Error `Cache_miss) (snd (Dns_cache.get cache 0L subname Ns)) ;
   Alcotest.check cached_r "cache with A nodata results in a record"
-    (Ok (`Entry a)) (Dns_cache.get cache 0L name A) ;
+    (Ok (`Entry a)) (snd (Dns_cache.get cache 0L name A)) ;
   Alcotest.check cached_r "cache with A nodata results in cache miss for NS'"
-    (Error `Cache_miss) (Dns_cache.get cache 0L name Ns) ;
-  Dns_cache.set cache 0L subname A AuthoritativeAnswer (`Entry a);
+    (Error `Cache_miss) (snd (Dns_cache.get cache 0L name Ns)) ;
+  let cache = Dns_cache.set cache 0L subname A AuthoritativeAnswer (`Entry a) in
   Alcotest.check cached_r "cache with A nodata results in nodata"
-    (Ok (`Entry a)) (Dns_cache.get cache 0L subname A)
+    (Ok (`Entry a)) (snd (Dns_cache.get cache 0L subname A))
 
 let cache_tests = [
   "empty cache", `Quick, empty_cache ;

--- a/test/cache.ml
+++ b/test/cache.ml
@@ -26,7 +26,7 @@ let cached_err =
   end in
   (module M: Alcotest.TESTABLE with type t = M.t)
 
-let res_eq a b =
+let entry_eq a b =
   match a, b with
   | `Entry b, `Entry b' -> Rr_map.equalb b b'
   | `No_data (name, soa), `No_data (name', soa') -> Domain_name.equal name name' && Dns.Soa.compare soa soa' = 0
@@ -38,10 +38,9 @@ let cached_ok =
   let module M = struct
     type t = Dns_cache.entry
     let pp ppf res = Dns_cache.pp_entry ppf res
-    let equal r r' = res_eq r r'
+    let equal r r' = entry_eq r r'
   end in
   (module M: Alcotest.TESTABLE with type t = M.t)
-
 
 let cached_r = Alcotest.(result cached_ok cached_err)
 
@@ -89,8 +88,70 @@ let cache_tests = [
   "cache nodata", `Quick, cache_nodata ;
 ]
 
+let empty = Dns_cache.empty 100
+
+let cname_empty_cache () =
+  Alcotest.check cached_r "empty cache results in Cache_miss"
+    (Error `Cache_miss)
+    (snd (Dns_cache.get_or_cname empty 0L (name "foo.com") A))
+
+let cname_cache_a () =
+  let name = name "foo.com" in
+  let a = Rr_map.(B (A, (250l, Ipv4_set.singleton (ip "1.2.3.4")))) in
+  let cache = Dns_cache.set empty 0L name A AuthoritativeAnswer (`Entry a) in
+  Alcotest.check cached_r "cache with A results in res"
+    (Ok (`Entry a))
+    (snd (Dns_cache.get_or_cname cache 0L name A)) ;
+  Alcotest.check cached_r "cache with A results in CacheMiss"
+    (Error `Cache_miss)
+    (snd (Dns_cache.get_or_cname cache 0L name Cname))
+
+let cname_cache_cname () =
+  let rel = name "bar.com" in
+  let name = name "foo.com" in
+  let cname = 250l, rel in
+  let cache = Dns_cache.set empty 0L name Cname AuthoritativeAnswer (`Entry (Rr_map.B (Cname, cname))) in
+  Alcotest.check cached_r "cache with CNAME results in res"
+    (Ok (`Entry (Rr_map.B (Cname, cname))))
+    (snd (Dns_cache.get_or_cname cache 0L name Cname)) ;
+  Alcotest.check cached_r "cache with CNAME results in res for A"
+    (Ok (`Entry (Rr_map.B (Cname, cname))))
+    (snd (Dns_cache.get_or_cname cache 0L name A)) ;
+  Alcotest.check cached_r "cache with CNAME results in res for NS"
+    (Ok (`Entry (Rr_map.B (Cname, cname))))
+    (snd (Dns_cache.get_or_cname cache 0L name Ns))
+
+let cname_cache_cname_nodata () =
+  let rel = name "bar.com" in
+  let name = name "foo.com" in
+  let cname = 250l, rel in
+  let bad_soa = invalid_soa name in
+  let cache =
+    Dns_cache.set
+      (Dns_cache.set empty 0L name Cname AuthoritativeAnswer
+         (`Entry (Rr_map.B (Cname, cname))))
+      0L name Ns AuthoritativeAnswer (`No_data (name, bad_soa))
+  in
+  Alcotest.check cached_r "cache with CNAME results in res"
+    (Ok (`Entry (B (Cname, cname))))
+    (snd (Dns_cache.get_or_cname cache 0L name Cname)) ;
+  Alcotest.check cached_r "cache with CNAME results in res for NS"
+    (Ok (`Entry (B (Cname, cname))))
+    (snd (Dns_cache.get_or_cname cache 0L name Ns)) ;
+  Alcotest.check cached_r "cache with CNAME results in res for A"
+    (Ok (`Entry (B (Cname, cname))))
+    (snd (Dns_cache.get_or_cname cache 0L name A))
+
+let cname_cache_tests = [
+  "empty cache", `Quick, cname_empty_cache ;
+  "cache with A", `Quick, cname_cache_a ;
+  "cache with CNAME", `Quick, cname_cache_cname ;
+  "cache with another cname", `Quick, cname_cache_cname_nodata ;
+]
+
 let tests = [
-    "cache tests", cache_tests;
+  "cache tests", cache_tests;
+  "cname cache tests", cname_cache_tests;
 ]
 
 let () = Alcotest.run "DNS cache tests" tests


### PR DESCRIPTION
- use a LRU.F (to cut down on memory usage) instead of LRU.M
- provide Dns_cache.get_or_cname
- use Dns_cache in Dns_resolver (instead of Dns_resolver_cache)