### PR TITLE
resolver: remove "mode" - which defaults to `Recursive

### DIFF
--- a/resolver/dns_resolver.mli
+++ b/resolver/dns_resolver.mli
@@ -3,9 +3,8 @@
 type t
 (** The type of a DNS resolver. *)
 
-val create : ?size:int -> ?mode:[ `Recursive | `Stub ] -> int64 ->
-  (int -> Cstruct.t) -> Dns_server.Primary.s -> t
-(** [create ~size ~mode now rng primary] creates the value of a resolver,
+val create : ?size:int -> int64 -> (int -> Cstruct.t) -> Dns_server.Primary.s -> t
+(** [create ~size now rng primary] creates the value of a resolver,
    pre-filled with root NS and their IP addresses. *)
 
 val handle_buf : t -> Ptime.t -> int64 -> bool -> Dns.proto -> Ipaddr.t ->

--- a/resolver/dns_resolver_utils.mli
+++ b/resolver/dns_resolver_utils.mli
@@ -2,10 +2,10 @@
 
 open Dns
 
-val scrub : ?mode:[ `Recursive | `Stub ] -> [ `raw ] Domain_name.t -> Packet.Question.qtype -> Packet.t ->
+val scrub : [ `raw ] Domain_name.t -> Packet.Question.qtype -> Packet.t ->
   ((Rr_map.k * [ `raw ] Domain_name.t * Dns_cache.rank * Dns_cache.entry) list,
    Rcode.t) result
-(** [scrub ~mode bailiwick packet] returns a list of entries to-be-added to the
+(** [scrub bailiwick packet] returns a list of entries to-be-added to the
     cache. This respects only in-bailiwick resources records, and qualifies the
     [packet]. The purpose is to avoid cache poisoning by not accepting all
     resource records. *)


### PR DESCRIPTION
A stub resolver is still available as dns-stub. This simplifies the resolver code.