### PR TITLE
Dns: revise Rr_map.get_ttl and with_ttl to take 'a key -> 'a instead of b

### DIFF
--- a/resolver/dns_resolver_cache.ml
+++ b/resolver/dns_resolver_cache.ml
@@ -69,7 +69,7 @@ let follow_cname t ts typ ~name ttl ~alias =
                      Domain_name.pp name);
       `Query name, t
     | Ok `Entry (Rr_map.B (Cname, (_, alias))) ->
-      let acc' = Domain_name.Map.add name Rr_map.(singleton Cname (ttl, alias)) acc in
+      let acc' = Domain_name.Map.add name (Rr_map.singleton Cname (ttl, alias)) acc in
       if Domain_name.Map.mem alias acc then begin
         Logs.warn (fun m -> m "follow_cname: cycle detected") ;
         `Out (Rcode.NoError, acc', Name_rr_map.empty), t

--- a/src/dns.ml
+++ b/src/dns.ml
@@ -2023,7 +2023,7 @@ module Rr_map = struct
     in
     String.concat "\n" strs
 
-  let get_ttl : b -> int32 = fun (B (k, v)) ->
+  let ttl : type a. a key -> a -> int32 = fun k v ->
     match k, v with
     | Cname, (ttl, _) -> ttl
     | Mx, (ttl, _) -> ttl
@@ -2040,22 +2040,22 @@ module Rr_map = struct
     | Sshfp, (ttl, _) -> ttl
     | Unknown _, (ttl, _) -> ttl
 
-  let with_ttl : b -> int32 -> b = fun (B (k, v)) ttl ->
+  let with_ttl : type a. a key -> a -> int32 -> a = fun k v ttl ->
     match k, v with
-    | Cname, (_, cname) -> B (k, (ttl, cname))
-    | Mx, (_, mxs) -> B (k, (ttl, mxs))
-    | Ns, (_, ns) -> B (k, (ttl, ns))
-    | Ptr, (_, ptr) -> B (k, (ttl, ptr))
-    | Soa, soa -> B (k, soa)
-    | Txt, (_, txts) -> B (k, (ttl, txts))
-    | A, (_, ips) -> B (k, (ttl, ips))
-    | Aaaa, (_, ips) -> B (k, (ttl, ips))
-    | Srv, (_, srvs) -> B (k, (ttl, srvs))
-    | Dnskey, keys -> B (k, keys)
-    | Caa, (_, caas) -> B (k, (ttl, caas))
-    | Tlsa, (_, tlsas) -> B (k, (ttl, tlsas))
-    | Sshfp, (_, sshfps) -> B (k, (ttl, sshfps))
-    | Unknown _, (_, datas) -> B (k, (ttl, datas))
+    | Cname, (_, cname) -> ttl, cname
+    | Mx, (_, mxs) -> ttl, mxs
+    | Ns, (_, ns) -> ttl, ns
+    | Ptr, (_, ptr) -> ttl, ptr
+    | Soa, soa -> soa
+    | Txt, (_, txts) -> ttl, txts
+    | A, (_, ips) -> ttl, ips
+    | Aaaa, (_, ips) -> ttl, ips
+    | Srv, (_, srvs) -> ttl, srvs
+    | Dnskey, keys -> keys
+    | Caa, (_, caas) -> ttl, caas
+    | Tlsa, (_, tlsas) -> ttl, tlsas
+    | Sshfp, (_, sshfps) -> ttl, sshfps
+    | Unknown _, (_, datas) -> ttl, datas
 
   let split : type a. a key -> a -> a * a option = fun k v ->
     match k, v with

--- a/src/dns.mli
+++ b/src/dns.mli
@@ -758,11 +758,11 @@ module Rr_map : sig
   val text : ?origin:'a Domain_name.t -> ?default_ttl:int32 -> 'b Domain_name.t -> 'c rr -> 'c -> string
   (** [text ~origin ~default_ttl name k v] is the zone file data for [k, v]. *)
 
-  val get_ttl : b -> int32
-  (** [get_ttl b] returns the time-to-live of [b]. *)
+  val ttl : 'a key -> 'a -> int32
+  (** [get_ttl k v] returns the time-to-live of [v]. *)
 
-  val with_ttl : b -> int32 -> b
-  (** [with_ttl b ttl] updates [ttl] in [b]. *)
+  val with_ttl : 'a key -> 'a -> int32 -> 'a
+  (** [with_ttl k v ttl] updates [ttl] in [v]. *)
 
 end
 

--- a/zone/dns_zone_parser.mly
+++ b/zone/dns_zone_parser.mly
@@ -49,7 +49,9 @@ let parse_uint32 s =
 let parse_ipv6 s =
   Ipaddr.V6.of_string_exn s
 
-let add_to_map name (Rr_map.B (k, v)) = Name_rr_map.add name k v
+let add_to_map name ~ttl (Rr_map.B (k, v)) =
+  let v = Rr_map.with_ttl k v ttl in
+  Name_rr_map.add name k v
 %}
 
 %token EOF
@@ -104,11 +106,11 @@ origin: SORIGIN s domain { state.origin <- $3 }
 ttl: STTL s int32 { state.ttl <- $3 }
 
 rrline:
-   owner s int32 s rrclass s rr { state.zone <- add_to_map $1 (Rr_map.with_ttl $7 $3) state.zone }
- | owner s rrclass s int32 s rr { state.zone <- add_to_map $1 (Rr_map.with_ttl $7 $5) state.zone  }
- | owner s rrclass s rr { state.zone <- add_to_map $1 (Rr_map.with_ttl $5 state.ttl) state.zone }
- | owner s int32 s rr { state.zone <- add_to_map $1 (Rr_map.with_ttl $5 $3) state.zone }
- | owner s rr { state.zone <- add_to_map $1 (Rr_map.with_ttl $3 state.ttl) state.zone }
+   owner s int32 s rrclass s rr { state.zone <- add_to_map $1 ~ttl:$3 $7 state.zone }
+ | owner s rrclass s int32 s rr { state.zone <- add_to_map $1 ~ttl:$5 $7 state.zone  }
+ | owner s rrclass s rr { state.zone <- add_to_map $1 ~ttl:state.ttl $5 state.zone }
+ | owner s int32 s rr { state.zone <- add_to_map $1 ~ttl:$3 $5 state.zone }
+ | owner s rr { state.zone <- add_to_map $1 ~ttl:state.ttl $3 state.zone }
 
 rrclass:
    CLASS_IN {}


### PR DESCRIPTION
This also renames "get_ttl" to "ttl".

//cc @reynir 