### PR TITLE
client: With_tls functor

### DIFF
--- a/client/dns_client.mli
+++ b/client/dns_client.mli
@@ -67,6 +67,11 @@ module type S = sig
   val lift : 'a -> 'a io
 end
 
+module With_tls : functor (T : S) -> S
+  with type io_addr = Tls.Config.client * T.io_addr
+   and type +'a io = 'a T.io
+   and type stack = T.stack
+
 module Make : functor (T : S) ->
 sig
 

--- a/client/dune
+++ b/client/dune
@@ -2,5 +2,5 @@
   (name        dns_client)
   (public_name dns-client)
   (modules     dns_client)
-  (libraries   dns.cache domain-name dns randomconv rresult)
+  (libraries   dns.cache domain-name dns randomconv rresult tls)
   (wrapped     false))

--- a/dns-client.opam
+++ b/dns-client.opam
@@ -31,6 +31,7 @@ depends: [
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng" {>= "0.8.0"}
   "alcotest" {with-test}
+  "tls" {>= "0.14.0"}
 ]
 synopsis: "Pure DNS resolver API"
 description: """


### PR DESCRIPTION
This adds DNS-over-TLS (RFC 7858) to the dns-client. This compiles, but have not been tested (and clients need to be adapted, esp. the TLS authenticator needs to be provided).