### PR TITLE
dns-client.opam: remove unused lwt dependency for the pure client

### DIFF
--- a/dns-client.opam
+++ b/dns-client.opam
@@ -23,7 +23,6 @@ depends: [
   "randomconv" {>= "0.1.2"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "4.0.0"}
-  "lwt" {>= "4.2.1"}
   "mirage-stack" {>= "2.2.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}


### PR DESCRIPTION
fixes #271, thanks to @copy for reporting.