### PR TITLE
dns-client: make edns optional and configurable by API

### DIFF
--- a/app/dune
+++ b/app/dune
@@ -40,3 +40,10 @@
   (package      dns-cli)
   (libraries    dns dns-client.lwt dns-cli cmdliner mtime.clock.os
                 lwt.unix hex bos))
+
+(executable
+  (name extract_from_ipfire)
+  (public_name extract-from-ipfire)
+  (modules extract_from_ipfire)
+  (package dns-cli)
+  (libraries lambdasoup domain-name ipaddr dns-cli))

--- a/app/extract_from_ipfire.ml
+++ b/app/extract_from_ipfire.ml
@@ -1,0 +1,103 @@
+(* a utility that takes https://wiki.ipfire.org/dns/public-servers
+   as input and extracts a map from IP address to hostname *)
+
+let ( let* ) = Result.bind
+
+let get_ips data =
+  let* table =
+    Option.to_result ~none:(`Msg "could't find dns-over-tls-service table")
+      Lambdasoup.(parse data |> select_one "h2#dns-over-tls-service + table")
+    [@warning "-3"]
+  in
+  let tds = Lambdasoup.select "td" table in
+  let rec more cur acc = function
+    | a :: ip :: dn :: tl ->
+      let txt = Fmt.str "%s | %s | %s" (Lambdasoup.to_string a) (Lambdasoup.to_string ip) (Lambdasoup.to_string dn) in
+      begin match
+          let* ip =
+            Option.to_result ~none:(`Msg ("no IP in " ^ txt))
+              (Lambdasoup.leaf_text ip)
+          in
+          if ip = "" then Error (`Msg "IP is empty")
+          else
+            let* ip = Ipaddr.of_string ip in
+            let* dn =
+              match Lambdasoup.leaf_text dn, cur with
+              | None, None -> Error (`Msg ("no name " ^ txt))
+              | Some txt, _ when String.length txt > 0 ->
+                let* dn = Domain_name.of_string txt in
+                Domain_name.host dn
+              | _, Some name -> Ok name
+              | _, None -> Error (`Msg "no name")
+            in
+            Ok (ip, dn)
+        with
+        | Ok (ip, dn) -> more (Some dn) ((ip, dn) :: acc) tl
+        | Error `Msg msg ->
+          Logs.warn (fun m -> m "%s" msg) ;
+          more cur acc tl
+      end
+    | _ -> acc
+  in
+  Ok (more None [] (Lambdasoup.to_list tds))
+
+let read_file file =
+  try
+    let fh = open_in file in
+    try
+      let content = really_input_string fh (in_channel_length fh) in
+      close_in_noerr fh ;
+      Ok content
+    with _ ->
+      close_in_noerr fh;
+      Error (`Msg ("Error reading file: " ^ file))
+  with _ -> Error (`Msg ("Error opening file " ^ file))
+
+let write_file file data =
+  try
+    let fh = open_out file in
+    try
+      output_string fh data;
+      close_out_noerr fh;
+      Ok ()
+    with _ ->
+      close_out_noerr fh;
+      Error (`Msg ("Error writing file: " ^ file))
+  with _ -> Error (`Msg ("Error opening file " ^ file))
+
+let jump () file out =
+  let* data = read_file file in
+  let* ips = get_ips data in
+  let prefix = {|
+let ip_domain =
+|} in
+  let data =
+    List.map (fun (ip, dn) ->
+        Fmt.str "Ipaddr.Map.add (Ipaddr.of_string_exn %S) Domain_name.(host_exn (of_string_exn %S))"
+          (Ipaddr.to_string ip) (Domain_name.to_string dn))
+      ips
+  in
+  let data =
+    List.fold_left (fun acc s -> s ^ "\n(" ^ acc ^ ")")
+      "Ipaddr.Map.empty" data
+  in
+  let data = prefix ^ data in
+  match out with
+  | None -> Logs.app (fun m -> m "%s" data); Ok ()
+  | Some f -> write_file f data
+
+open Cmdliner
+
+let out =
+  let doc = "output file" in
+  Arg.(value & opt (some string) None & info [ "output" ] ~doc ~docv:"DATA")
+
+let data =
+  let doc = "data file" in
+  Arg.(required & pos 0 (some file) None & info [] ~doc ~docv:"DATA")
+
+let cmd =
+  Term.(term_result (const jump $ Dns_cli.setup_log $ data $ out)),
+  Term.info "extract_from_ipfire" ~version:"%%VERSION_NUM%%"
+
+let () = match Term.eval cmd with `Ok () -> exit 0 | _ -> exit 1

--- a/client/dns_client.ml
+++ b/client/dns_client.ml
@@ -146,11 +146,65 @@ module Pure = struct
 end
 
 (* Anycast address of uncensoreddns.org *)
-let default_resolver_hostname = Domain_name.(host_exn (of_string_exn "anycast.uncensoreddns.org"))
 let default_resolvers = [
   Ipaddr.of_string_exn "2001:67c:28a4::" ;
   Ipaddr.of_string_exn "91.239.100.100" ;
 ]
+
+(* generated on November 9th 2021 by app/extract_from_ipfire *)
+(* adjusted the IPv6 anycast from uncensoreddns.org *)
+let ip_domain =
+Ipaddr.Map.add (Ipaddr.of_string_exn "91.239.100.100") Domain_name.(host_exn (of_string_exn "anycast.uncensoreddns.org"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "2001:67c:28a4::") Domain_name.(host_exn (of_string_exn "anycast.uncensoreddns.org"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "1.1.1.1") Domain_name.(host_exn (of_string_exn "cloudflare-dns.com"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "1.0.0.1") Domain_name.(host_exn (of_string_exn "cloudflare-dns.com"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "2606:4700:4700::1111") Domain_name.(host_exn (of_string_exn "cloudflare-dns.com"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "2606:4700:4700::1001") Domain_name.(host_exn (of_string_exn "cloudflare-dns.com"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "5.1.66.255") Domain_name.(host_exn (of_string_exn "anycast01.ffmuc.net"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "2001:678:e68:f000::") Domain_name.(host_exn (of_string_exn "anycast01.ffmuc.net"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "5.1.66.255") Domain_name.(host_exn (of_string_exn "dot.ffmuc.net"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "2001:678:e68:f000::") Domain_name.(host_exn (of_string_exn "dot.ffmuc.net"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "185.222.222.222") Domain_name.(host_exn (of_string_exn "dns.sb"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "185.184.222.222") Domain_name.(host_exn (of_string_exn "dns.sb"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "2a09::") Domain_name.(host_exn (of_string_exn "dns.sb"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "2a09::1") Domain_name.(host_exn (of_string_exn "dns.sb"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "8.8.8.8") Domain_name.(host_exn (of_string_exn "dns.google"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "8.8.4.4") Domain_name.(host_exn (of_string_exn "dns.google"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "146.255.56.98") Domain_name.(host_exn (of_string_exn "dot1.applied-privacy.net"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "2a01:4f8:c0c:83ed::1") Domain_name.(host_exn (of_string_exn "dot1.applied-privacy.net"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "199.58.81.218") Domain_name.(host_exn (of_string_exn "dns.cmrg.net"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "2001:470:1c:76d::53") Domain_name.(host_exn (of_string_exn "dns.cmrg.net"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "185.95.218.42") Domain_name.(host_exn (of_string_exn "dns.digitale-gesellschaft.ch"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "185.95.218.43") Domain_name.(host_exn (of_string_exn "dns.digitale-gesellschaft.ch"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "2a05:fc84::42") Domain_name.(host_exn (of_string_exn "dns.digitale-gesellschaft.ch"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "2a05:fc84::43") Domain_name.(host_exn (of_string_exn "dns.digitale-gesellschaft.ch"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "140.238.215.192") Domain_name.(host_exn (of_string_exn "dot.post-factum.tk"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "5.9.164.112") Domain_name.(host_exn (of_string_exn "dns3.digitalcourage.de"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "81.3.27.54") Domain_name.(host_exn (of_string_exn "recursor01.dns.ipfire.org"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "2001:678:b28::54") Domain_name.(host_exn (of_string_exn "recursor01.dns.ipfire.org"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "81.3.27.54") Domain_name.(host_exn (of_string_exn "recursor01.dns.lightningwirelabs.com"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "2001:678:b28::54") Domain_name.(host_exn (of_string_exn "recursor01.dns.lightningwirelabs.com"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "89.233.43.71") Domain_name.(host_exn (of_string_exn "unicast.uncensoreddns.org"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "2a01:3a0:53:53::") Domain_name.(host_exn (of_string_exn "unicast.uncensoreddns.org"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "95.216.24.230") Domain_name.(host_exn (of_string_exn "fi.dot.dns.snopyta.org"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "2a01:4f9:2a:1919::9301") Domain_name.(host_exn (of_string_exn "fi.dot.dns.snopyta.org"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "89.234.186.112") Domain_name.(host_exn (of_string_exn "dns.neutopia.org"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "2a00:5884:8209::2") Domain_name.(host_exn (of_string_exn "dns.neutopia.org"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "158.64.1.29") Domain_name.(host_exn (of_string_exn "kaitain.restena.lu"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "2001:a18:1::29") Domain_name.(host_exn (of_string_exn "kaitain.restena.lu"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "185.49.141.37") Domain_name.(host_exn (of_string_exn "getdnsapi.net"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "2a04:b900:0:100::37") Domain_name.(host_exn (of_string_exn "getdnsapi.net"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "145.100.185.17") Domain_name.(host_exn (of_string_exn "dnsovertls2.sinodun.com"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "145.100.185.18") Domain_name.(host_exn (of_string_exn "dnsovertls3.sinodun.com"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "2001:610:1:40ba:145:100:185:17") Domain_name.(host_exn (of_string_exn "dnsovertls3.sinodun.com"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "2001:610:1:40ba:145:100:185:18") Domain_name.(host_exn (of_string_exn "dnsovertls3.sinodun.com"))
+(Ipaddr.Map.add (Ipaddr.of_string_exn "96.113.151.145") Domain_name.(host_exn (of_string_exn "dot.xfinity.com"))
+(Ipaddr.Map.empty)))))))))))))))))))))))))))))))))))))))))))))
+
+let known_name ip =
+  match Ipaddr.Map.find_opt ip ip_domain with
+  | None -> Some ip, None
+  | Some name -> None, Some name
 
 module type S = sig
   type context

--- a/client/dns_client.mli
+++ b/client/dns_client.mli
@@ -54,11 +54,9 @@ module type S = sig
   val connect : t -> (context, [> `Msg of string ]) result io
   (** [connect addr] is a new connection ([context]) to [addr], or an error. *)
 
-  val send : context -> Cstruct.t -> (unit, [> `Msg of string ]) result io
-  (** [send context buffer] sends [buffer] to the [context] upstream.*)
-
-  val recv : context -> (Cstruct.t, [> `Msg of string ]) result io
-  (** [recv context] tries to read a [buffer] from the [context] downstream.*)
+  val send_recv : context -> Cstruct.t -> (Cstruct.t, [> `Msg of string ]) result io
+  (** [send_recv context buffer] sends [buffer] to the [context] upstream, and
+      then reads a buffer. *)
 
   val close : context -> unit io
   (** [close context] closes the [context], freeing up resources. *)

--- a/client/dns_client.mli
+++ b/client/dns_client.mli
@@ -3,12 +3,17 @@
         and [connect] and so on. leaving this stuff here for now until a
         better solution presents itself. *)
 
-val default_resolver_hostname : [`host] Domain_name.t
-
 val default_resolvers : Ipaddr.t list
 (** [default_resolver] is a list of IPv6 and IPv4 address of the default
     resolver. Currently it is the IP address of the UncensoredDNS.org
     anycast service. *)
+
+val known_name : Ipaddr.t -> Ipaddr.t option * [`host] Domain_name.t option
+(** [known_name ip] returns either [Some ip, None] if the IP is not known,
+    or [Some name, None] if the IP address is known as a public resolver. The
+    lookup is done by a map from ipfire.org. This allows DNS-over-TLS clients
+    where the server has a certificate with only a domain name, not an IP
+    address. *)
 
 module type S = sig
   type context

--- a/dns-cli.opam
+++ b/dns-cli.opam
@@ -33,6 +33,7 @@ depends: [
   "randomconv"
   "alcotest" {with-test}
   "lambdasoup"
+  "domain-name"
 ]
 
 build: [

--- a/dns-cli.opam
+++ b/dns-cli.opam
@@ -32,6 +32,7 @@ depends: [
   "lwt" {>= "4.0.0"}
   "randomconv"
   "alcotest" {with-test}
+  "lambdasoup"
 ]
 
 build: [

--- a/lwt/client/dns_client_lwt.ml
+++ b/lwt/client/dns_client_lwt.ml
@@ -116,24 +116,20 @@ module Transport : Dns_client.S
           | Ok a -> a
           | Error `Msg m -> invalid_arg ("failed to load trust anchors: " ^ m)
         in
+        let tls_and_plain ip =
+          let auth_ip, peer_name = Dns_client.known_name ip in
+          let tls = Tls.Config.client ~authenticator ?ip:auth_ip ?peer_name () in
+          [ `Tls (tls, ip, 853) ; `Plaintext (ip, 53) ]
+        in
         match
           let ( let* ) = Result.bind in
           let* data = read_file "/etc/resolv.conf" in
           let* ns = Dns_resolvconf.parse data in
           Ok (List.flatten
-                (List.map
-                   (fun (`Nameserver ip) ->
-                      let tls = Tls.Config.client ~authenticator ~ip () in
-                      [ `Tls (tls, ip, 853) ; `Plaintext (ip, 53) ])
-                   ns))
+                (List.map (fun (`Nameserver ip) -> tls_and_plain ip) ns))
         with
         | Error _  | Ok [] ->
-          let peer_name = Dns_client.default_resolver_hostname in
-          let tls_config = Tls.Config.client ~authenticator ~peer_name () in
-          List.flatten
-            (List.map (fun ip -> [
-                   `Tls (tls_config, ip, 853); `Plaintext (ip, 53)
-                 ]) Dns_client.default_resolvers)
+          List.flatten (List.map tls_and_plain Dns_client.default_resolvers)
         | Ok ips -> ips
     in
     let t = {

--- a/lwt/client/dns_client_lwt.ml
+++ b/lwt/client/dns_client_lwt.ml
@@ -23,11 +23,7 @@ module Transport : Dns_client.S
     mutable waiters : ((Ipaddr.t * int) * Lwt_unix.file_descr, [ `Msg of string ]) result Lwt.u Happy_eyeballs.Waiter_map.t ;
     timer_condition : unit Lwt_condition.t ;
   }
-  type context = {
-    t : t ;
-    mutable timeout_ns : int64 ;
-    mutable data : Cstruct.t ;
-  }
+  type context = t
 
   let read_file file =
     try
@@ -147,16 +143,12 @@ module Transport : Dns_client.S
   let nameservers { nameservers ; _ } = `Tcp, nameservers
   let rng = Mirage_crypto_rng.generate ?g:None
 
-  let with_timeout ctx f =
+  let with_timeout timeout f =
     let timeout =
-      Lwt_unix.sleep (Duration.to_f ctx.timeout_ns) >|= fun () ->
+      Lwt_unix.sleep (Duration.to_f timeout) >|= fun () ->
       Error (`Msg "DNS request timeout")
     in
-    let start = clock () in
-    Lwt.pick [ f ; timeout ] >|= fun result ->
-    let stop = clock () in
-    ctx.timeout_ns <- Int64.sub ctx.timeout_ns (Int64.sub stop start);
-    result
+    Lwt.pick [ f ; timeout ]
 
   let close _ = Lwt.return_unit
 
@@ -174,25 +166,23 @@ module Transport : Dns_client.S
         Lwt_result.ok (Tls_lwt.Unix.write fd tx))
       (fun e -> Lwt.return (Error (`Msg (Printexc.to_string e))))
 
-  let send ctx tx =
-    if Cstruct.length tx > 2 then
-      match ctx.t.fd with
+  let send_recv (t : context) tx =
+    if Cstruct.length tx > 4 then
+      match t.fd with
       | None -> Lwt.return (Error (`Msg "no connection to the nameserver established"))
       | Some fd ->
-        ctx.data <- tx;
-        with_timeout ctx (send_query fd tx)
+        with_timeout t.timeout_ns
+          (let open Lwt_result.Infix in
+           send_query fd tx >>= fun () ->
+           let cond = Lwt_condition.create () in
+           let id = Cstruct.BE.get_uint16 tx 2 in
+           t.requests <- IM.add id (tx, cond) t.requests;
+           let open Lwt.Infix in
+           Lwt_condition.wait cond >|= fun data ->
+           t.requests <- IM.remove id t.requests;
+           match data with Ok o -> Ok o | Error `Msg e -> Error (`Msg e))
     else
-      Lwt.return (Error (`Msg "invalid DNS packet (data length <= 2)"))
-
-  let recv ctx =
-    let cond = Lwt_condition.create () in
-    let id = Cstruct.BE.get_uint16 ctx.data 2 in
-    ctx.t.requests <- IM.add id (ctx.data, cond) ctx.t.requests;
-    with_timeout ctx (Lwt_condition.wait cond) >|= fun data ->
-    ctx.t.requests <- IM.remove id ctx.t.requests;
-    match data with
-    | Ok cs -> Ok cs
-    | Error `Msg m -> Error (`Msg m)
+      Lwt.return (Error (`Msg "invalid DNS packet (data length <= 4)"))
 
   let bind = Lwt.bind
   let lift = Lwt.return
@@ -313,9 +303,8 @@ module Transport : Dns_client.S
                  connect_via_tcp_to_ns t ns')
 
   let connect t =
-    let ctx = { t ; timeout_ns = t.timeout_ns ; data = Cstruct.empty } in
     connect_via_tcp_to_ns t t.nameservers >|= function
-    | Ok () -> Ok ctx
+    | Ok () -> Ok t
     | Error `Msg msg -> Error (`Msg msg)
 end
 

--- a/mirage/client/dns_client_mirage.ml
+++ b/mirage/client/dns_client_mirage.ml
@@ -96,13 +96,13 @@ module Make (R : Mirage_random.S) (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) 
             | Ok a -> a
             | Error `Msg m -> invalid_arg ("bad CA certificates " ^ m)
           in
-          let tls_cfg =
-            let peer_name = Dns_client.default_resolver_hostname in
-            Tls.Config.client ~authenticator ~peer_name ()
+          let tls_cfg ip =
+            let ip, peer_name = Dns_client.known_name ip in
+            Tls.Config.client ~authenticator ?ip ?peer_name ()
           in
           List.flatten
             (List.map
-               (fun ip -> [ `Tls (tls_cfg, ip, 853) ; `Plaintext (ip, 53) ])
+               (fun ip -> [ `Tls (tls_cfg ip, ip, 853) ; `Plaintext (ip, 53) ])
                Dns_client.default_resolvers)
         | Some (`Udp, _) -> invalid_arg "UDP is not supported"
         | Some (`Tcp, ns) -> ns

--- a/test/client.ml
+++ b/test/client.ml
@@ -15,7 +15,7 @@ module Make_query_tests = struct
   let produces_same_output () =
     let rng = Cstruct.create in
     let name:'a Domain_name.t = Domain_name.of_string_exn "example.com" in
-    let actual, _state = Dns_client.Pure.make_query rng `Tcp name Dns.Rr_map.A in
+    let actual, _state = Dns_client.Pure.make_query rng `Tcp `Auto name Dns.Rr_map.A in
     let expected = Cstruct.of_hex
         "00 2e 00 00 01 00 00 01  00 00 00 00 00 01 07 65
          78 61 6d 70 6c 65 03 63  6f 6d 00 00 01 00 01 00
@@ -44,7 +44,7 @@ module Parse_response_tests = struct
     (* This `rng` generates zeros, used for the query ID above *)
     let rng = Cstruct.create in
     let name:'a Domain_name.t = Domain_name.of_string_exn "foo.com" in
-    let _actual, state = Dns_client.Pure.make_query rng `Tcp name Dns.Rr_map.A in
+    let _actual, state = Dns_client.Pure.make_query rng `Tcp `Auto name Dns.Rr_map.A in
     match Dns_client.Pure.parse_response state ipv4_buf with
     | Ok `Data _ -> () (* TODO: Alcotest TESTABLE for this return value *)
     | _ -> ignore(failwith "error")
@@ -66,7 +66,7 @@ module Parse_response_tests = struct
     (* This `rng` generates zeros, used for the query ID above *)
     let rng = Cstruct.create in
     let name:'a Domain_name.t = Domain_name.of_string_exn "foo.com" in
-    let _actual, state = Dns_client.Pure.make_query rng `Tcp name Dns.Rr_map.A in
+    let _actual, state = Dns_client.Pure.make_query rng `Tcp `Auto name Dns.Rr_map.A in
     match Dns_client.Pure.parse_response state ipv4_buf with
     | Error `Msg _ -> ()
     | __ -> failwith "should have rejected mismatched input"

--- a/test/client.ml
+++ b/test/client.ml
@@ -109,12 +109,10 @@ module Transport (*: Dns_client.S
 
   let connect _ = Ok default_debug_info
 
-  let send _ _ = Ok ()
-
-  let recv (mock_responses : context) =
+  let send_recv (mock_responses : context) _ =
     match !mock_responses with
-      | [] -> failwith("nothing to recv from the wire")
-      | hd::tail -> mock_responses := tail; Ok hd
+    | [] -> failwith("nothing to recv from the wire")
+    | hd::tail -> mock_responses := tail; Ok hd
 end
 
 (* Now that we have our {!Transport} implementation we can include the logic

--- a/unix/client/dns_client_unix.ml
+++ b/unix/client/dns_client_unix.ml
@@ -97,29 +97,29 @@ module Transport : Dns_client.S
       with e ->
         Error (`Msg (Printexc.to_string e))
 
-  let send ctx (tx : Cstruct.t) =
+  let send_recv ctx (tx : Cstruct.t) =
     let str = Cstruct.to_string tx in
     try
-      with_timeout ctx (fun fd ->
-        Unix.setsockopt_float fd Unix.SO_SNDTIMEO (Duration.to_f ctx.timeout_ns);
-        let res = Unix.send_substring fd str 0 (String.length str) [] in
-        if res <> String.length str
-        then
-          Error (`Msg ("Broken write to upstream NS" ^ (string_of_int res)))
-        else Ok ())
-   with e ->
-     Error (`Msg (Printexc.to_string e))
-
-  let recv ctx =
-    let buffer = Bytes.make 2048 '\000' in
-    try
-      with_timeout ctx (fun fd ->
-        Unix.setsockopt_float fd Unix.SO_RCVTIMEO (Duration.to_f ctx.timeout_ns);
-        let x = Unix.recv fd buffer 0 (Bytes.length buffer) [] in
-        if x > 0 && x <= Bytes.length buffer then
-          Ok (Cstruct.of_bytes buffer ~len:x)
-        else
-          Error (`Msg "Reading from NS socket failed"))
+      begin match
+          with_timeout ctx (fun fd ->
+              Unix.setsockopt_float fd Unix.SO_SNDTIMEO (Duration.to_f ctx.timeout_ns);
+              let res = Unix.send_substring fd str 0 (String.length str) [] in
+              if res <> String.length str then
+                Error (`Msg ("Broken write to upstream NS" ^ (string_of_int res)))
+              else
+                Ok ())
+        with
+        | Error _ as e -> e
+        | Ok () ->
+          let buffer = Bytes.make 2048 '\000' in
+          with_timeout ctx (fun fd ->
+              Unix.setsockopt_float fd Unix.SO_RCVTIMEO (Duration.to_f ctx.timeout_ns);
+              let x = Unix.recv fd buffer 0 (Bytes.length buffer) [] in
+              if x > 0 && x <= Bytes.length buffer then
+                Ok (Cstruct.of_bytes buffer ~len:x)
+              else
+                Error (`Msg "Reading from NS socket failed"))
+      end
     with e ->
       Error (`Msg (Printexc.to_string e))
 end


### PR DESCRIPTION
val Dns_client.Make.create now includes
`` ?edns:[`None | `Auto | `Manual of Dns.Edns.t])``

as suggested by @orbitz in #276