### PR TITLE
make polymorphic variant errors open

### DIFF
--- a/cache/dns_cache.ml
+++ b/cache/dns_cache.ml
@@ -242,10 +242,10 @@ let get_any cache ts name =
 
 let get_or_cname : type a . t -> int64 -> [`raw] Domain_name.t -> a Rr_map.key ->
   t * ([ a entry | `Alias of int32 * [`raw] Domain_name.t] * rank,
-       [ `Cache_drop | `Cache_miss ]) result =
+       [> `Cache_drop | `Cache_miss ]) result =
   fun cache ts name query_type ->
   metrics cache `Lookup;
-  let map_result : _ -> t * ([ a entry | `Alias of int32 * [`raw] Domain_name.t] * rank, [ `Cache_drop | `Cache_miss ]) result = function
+  let map_result : _ -> t * ([ a entry | `Alias of int32 * [`raw] Domain_name.t] * rank, [> `Cache_drop | `Cache_miss ]) result = function
     | Error e -> metrics cache `Miss; cache, Error e
     | Ok ((created, rank), entry) ->
       match update_ttl query_type entry ~created ~now:ts with

--- a/cache/dns_cache.mli
+++ b/cache/dns_cache.mli
@@ -56,7 +56,7 @@ val pp_entry : 'a Rr_map.key -> 'a entry Fmt.t
 (** [pp_entry ppf entry] pretty-prints [entry] on [ppf]. *)
 
 val get : t -> int64 -> [ `raw ] Domain_name.t -> 'a Rr_map.key ->
-  t * ('a entry * rank, [ `Cache_miss | `Cache_drop ]) result
+  t * ('a entry * rank, [> `Cache_miss | `Cache_drop ]) result
 (** [get cache timestamp type name] retrieves the query [type, name] from the
     [cache] using [timestamp]. If the time to live is exceeded, a [`Cache_drop]
     is returned. If there is no entry in the cache, a [`Cache_miss] is
@@ -64,19 +64,19 @@ val get : t -> int64 -> [ `raw ] Domain_name.t -> 'a Rr_map.key ->
 
 val get_or_cname : t -> int64 -> [ `raw ] Domain_name.t -> 'a Rr_map.key ->
   t * ([ 'a entry | `Alias of int32 * [`raw] Domain_name.t] * rank,
-       [ `Cache_miss | `Cache_drop ]) result
+       [> `Cache_miss | `Cache_drop ]) result
 (** [get_or_cname cache timestamp type name] is the same as [get], but if a
     [`Cache_miss] is encountered, a lookup for an alias (CNAME) is done. *)
 
 val get_any : t -> int64 -> [ `raw ] Domain_name.t ->
   t * ([ `Entries of Rr_map.t
        | `No_domain of [ `raw ] Domain_name.t * Soa.t ] * rank,
-       [ `Cache_miss | `Cache_drop ]) result
+       [> `Cache_miss | `Cache_drop ]) result
 (** [get_any cache timestamp name] retrieves all resource records for [name]
     in [cache]. *)
 
 val get_nsec3 : t -> int64 -> [ `raw ] Domain_name.t ->
-  t * (([`raw] Domain_name.t * Nsec3.t) list, [ `Cache_miss | `Cache_drop ]) result
+  t * (([`raw] Domain_name.t * Nsec3.t) list, [> `Cache_miss | `Cache_drop ]) result
 (** [get_nsec3 cache timestamp name] retrieves all nsec3 resource records for
     the zone [name]. *)
 

--- a/client/dns_client.ml
+++ b/client/dns_client.ml
@@ -158,7 +158,7 @@ module Pure = struct
         | `Partial
         | `No_data of [`raw] Domain_name.t * Soa.t
         | `No_domain of [`raw] Domain_name.t * Soa.t ],
-        [`Msg of string]) result =
+        [> `Msg of string]) result =
     fun state buf ->
     match parse_response state buf with
     | Error `Partial -> Ok `Partial

--- a/client/dns_client.mli
+++ b/client/dns_client.mli
@@ -153,7 +153,7 @@ module Pure : sig
       and [query_state] is the information required to validate the response. *)
 
   val parse_response : 'query_type Dns.Rr_map.key query_state -> Cstruct.t ->
-    (Dns.Packet.reply, [ `Partial | `Msg of string]) result
+    (Dns.Packet.reply, [> `Partial | `Msg of string]) result
   (** [parse_response query_state response] is the information contained in
       [response] parsed using [query_state] when the query was successful, or
       an [`Msg message] if the [response] did not match the [query_state]
@@ -173,7 +173,7 @@ module Pure : sig
       | `Partial
       | `No_data of [`raw] Domain_name.t * Dns.Soa.t
       | `No_domain of [`raw] Domain_name.t * Dns.Soa.t ],
-      [`Msg of string]) result
+      [> `Msg of string]) result
   (** [handle_response query_state response] is the information contained in
       [response] parsed using [query_state] when the query was successful, or
       an [`Msg message] if the [response] did not match the [query_state]

--- a/mirage/certify/dns_certify_mirage.mli
+++ b/mirage/certify/dns_certify_mirage.mli
@@ -6,7 +6,7 @@ module Make (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S) 
     ?additional_hostnames:[ `raw ] Domain_name.t list ->
     ?key_type:X509.Key_type.t -> ?key_data:string -> ?key_seed:string ->
     ?bits:int -> S.TCP.ipaddr -> int ->
-    (X509.Certificate.t list * X509.Private_key.t, [ `Msg of string ]) result Lwt.t
+    (X509.Certificate.t list * X509.Private_key.t, [> `Msg of string ]) result Lwt.t
   (** [retrieve_certificate stack ~dns_key ~hostname ~key_type ~key_data ~key_seed ~bits server_ip port]
       generates a private key (using [key_type], [key_data], [key_seed], and
       [bits]), a certificate signing request for the given [hostname] and

--- a/server/dns_trie.mli
+++ b/server/dns_trie.mli
@@ -84,7 +84,7 @@ type zone_check = [ `Missing_soa of [ `raw ] Domain_name.t
 val pp_zone_check : zone_check Fmt.t
 (** [pp_err ppf err] pretty prints the error [err]. *)
 
-val check : t -> (unit, zone_check) result
+val check : t -> (unit, [> zone_check]) result
 (** [check t] checks all invariants. *)
 
 
@@ -100,20 +100,20 @@ val pp_e : e Fmt.t
 (** [pp_e ppf e] pretty-prints [e] on [ppf]. *)
 
 val zone : 'a Domain_name.t -> t ->
-  ([ `raw ] Domain_name.t * Soa.t, e) result
+  ([ `raw ] Domain_name.t * Soa.t, [> e]) result
 (** [zone k t] returns either the zone and soa for [k] in [t], or an error. *)
 
 val lookup_with_cname : 'a Domain_name.t -> 'b Rr_map.key -> t ->
-  (Rr_map.b * ([ `raw ] Domain_name.t * int32 * Domain_name.Host_set.t), e) result
+  (Rr_map.b * ([ `raw ] Domain_name.t * int32 * Domain_name.Host_set.t), [> e]) result
 (** [lookup_with_cname k ty t] finds [k, ty] in [t]. It either returns the found
     resource record set and authority information, a cname alias and authority
     information, or an error. *)
 
-val lookup : 'a Domain_name.t -> 'b Rr_map.key -> t -> ('b, e) result
+val lookup : 'a Domain_name.t -> 'b Rr_map.key -> t -> ('b, [> e]) result
 (** [lookup k ty t] finds [k, ty] in [t], which may lead to an error. *)
 
 val lookup_any : 'a Domain_name.t -> t ->
-  (Rr_map.t * ([ `raw ] Domain_name.t * int32 * Domain_name.Host_set.t), e) result
+  (Rr_map.t * ([ `raw ] Domain_name.t * int32 * Domain_name.Host_set.t), [> e]) result
 (** [lookup_any k t] looks up all resource records of [k] in [t], and returns
     that and the authority information. *)
 
@@ -123,7 +123,7 @@ val lookup_glue : 'a Domain_name.t -> t ->
     potential DNS invariants, e.g. that there is no surrounding zone. *)
 
 val entries : 'a Domain_name.t -> t ->
-  (Dns.Soa.t * Rr_map.t Domain_name.Map.t, e) result
+  (Dns.Soa.t * Rr_map.t Domain_name.Map.t, [> e]) result
 (** [entries name t] returns either the SOA and all entries for the requested
     [name], or an error. *)
 

--- a/src/dns.mli
+++ b/src/dns.mli
@@ -1273,7 +1273,7 @@ module Packet : sig
   val pp_err : err Fmt.t
   (** [pp_err ppf err] pretty-prints the decode error [err] on [ppf]. *)
 
-  val decode : Cstruct.t -> (t, err) result
+  val decode : Cstruct.t -> (t, [> err]) result
   (** [decode cs] decode the binary data [cs] to a DNS packet [t] or an error. *)
 
   type mismatch = [ `Not_a_reply of request
@@ -1286,7 +1286,7 @@ module Packet : sig
   val pp_mismatch : mismatch Fmt.t
   (** [pp_mismatch ppf m] pretty-prints the mismatch [m] on [ppf]. *)
 
-  val reply_matches_request : request:t -> t -> (reply, mismatch) result
+  val reply_matches_request : request:t -> t -> (reply, [> mismatch]) result
   (** [reply_matches_request ~request reply] validates
       that the [reply] match the [request], and returns either
       [Ok data] or an [Error]. The following basic checks are

--- a/tsig/dns_tsig.mli
+++ b/tsig/dns_tsig.mli
@@ -24,7 +24,7 @@ val pp_s : s Fmt.t
 (** [pp_s ppf s] pretty-prints [s] on [ppf]. *)
 
 val encode_and_sign : ?proto:proto -> ?mac:Cstruct.t -> Packet.t -> Ptime.t ->
-  Dns.Dnskey.t -> 'a Domain_name.t -> (Cstruct.t * Cstruct.t, s) result
+  Dns.Dnskey.t -> 'a Domain_name.t -> (Cstruct.t * Cstruct.t, [> s]) result
 (** [encode_and_sign ~proto ~mac t now dnskey name] signs and encodes the DNS
     packet. If a reply to a request is signed, the [mac] argument should be the
     message authentication code from the request (needed to sign the reply).
@@ -45,7 +45,7 @@ val pp_e : e Fmt.t
 
 val decode_and_verify : Ptime.t -> Dnskey.t -> 'a Domain_name.t ->
   ?mac:Cstruct.t -> Cstruct.t ->
-  (Packet.t * Tsig.t * Cstruct.t, e) result
+  (Packet.t * Tsig.t * Cstruct.t, [> e]) result
 (** [decode_and_verify now dnskey name ~mac buffer] decodes and verifies the
    given buffer using the key material, resulting in a DNS packet, a signature,
    and the [mac], or a failure. The optional [mac] argument should be provided


### PR DESCRIPTION
For composing errors. I tried to be thorough, but personally I only care about dns.mli. I skipped `Dns.Tsig_op.e`  because it propagates all the way to `Dns_server.t` (which contains a `Tsig_op.verify`, which returns this error).