### PR TITLE
Use menhir parser

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,3 @@
-(lang dune 1.2)
+(lang dune 1.4)
 (name dns)
+(using menhir 2.0)

--- a/resolvconf/dune
+++ b/resolvconf/dune
@@ -5,5 +5,6 @@
  (libraries ipaddr)
  (wrapped false))
 
-(ocamlyacc resolvconf_parser)
+(menhir
+ (modules resolvconf_parser))
 (ocamllex resolvconf_lexer)

--- a/zone/dune
+++ b/zone/dune
@@ -5,5 +5,6 @@
  (libraries dns dns-server logs)
  (wrapped false))
 
-(ocamlyacc dns_zone_parser)
+(menhir
+ (modules dns_zone_parser))
 (ocamllex dns_zone_lexer)


### PR DESCRIPTION
Addresses https://github.com/mirage/ocaml-dns/issues/203

Work still needs to be done to improve error messages.

Dune is upgraded from 1.2 to 1.4 to support menhir 2.0 which gives nonterminal symbol type inference, fixing the error:
```
Error: the code back-end requires the type of every nonterminal symbol to be
known. Please specify the type of every symbol via %type declarations, or
enable type inference (look up --infer in the manual).
Type inference is automatically enabled when Menhir is used via Dune,
provided the dune-project file says (using menhir 2.0) or later.
```