### PR TITLE
dns-certify-mirage: use X509.Private_key.of_string

### DIFF
--- a/dns-certify.opam
+++ b/dns-certify.opam
@@ -15,7 +15,7 @@ depends: [
   "dns-mirage" {= version}
   "randomconv" {>= "0.1.2"}
   "duration" {>= "0.1.2"}
-  "x509" {>= "0.13.0"}
+  "x509" {>= "0.15.2"}
   "lwt" {>= "4.2.1"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}


### PR DESCRIPTION
the only semantic difference is when neither "key_data" nor "key_seed" is provided, in which case we error out now.

I think that's fine (I checked all cloned unikernels on my hard drive), but am happy to hear other thoughts.