### PR TITLE
Resolv.conf parser: allow zone idx (RFC 4007) be present for IPv6 addresses

### DIFF
--- a/resolvconf/dns_resolvconf.ml
+++ b/resolvconf/dns_resolvconf.ml
@@ -1,10 +1,14 @@
 let parse buf =
   try
+    Resolvconf_state.reset ();
     let buf =
       if String.(get buf (pred (length buf))) = '\n' then buf else buf ^ "\n"
     in
     let lexbuf = Lexing.from_string buf in
     Ok (Resolvconf_parser.resolvconf Resolvconf_lexer.lex lexbuf)
   with
-    | Parsing.Parse_error -> Error (`Msg "parse error")
-    | exn -> Error (`Msg (Printexc.to_string exn))
+  | Parsing.Parse_error ->
+    Error (`Msg (Fmt.str "parse error at line %d" Resolvconf_state.(state.lineno)))
+  | exn ->
+    Error (`Msg (Fmt.str "error at line %d: %s" Resolvconf_state.(state.lineno)
+                   (Printexc.to_string exn)))

--- a/resolvconf/dune
+++ b/resolvconf/dune
@@ -1,8 +1,8 @@
 (library
  (name dns_resolvconv)
  (public_name dns-client.resolvconf)
- (private_modules resolvconf_lexer resolvconf_parser)
- (libraries ipaddr)
+ (private_modules resolvconf_lexer resolvconf_parser resolvconf_state)
+ (libraries ipaddr fmt)
  (wrapped false))
 
 (ocamlyacc resolvconf_parser)

--- a/resolvconf/resolvconf_lexer.mll
+++ b/resolvconf/resolvconf_lexer.mll
@@ -1,25 +1,30 @@
 {
+open Resolvconf_state
 open Resolvconf_parser
 }
 
 let ipv4 = (['0'-'9']+ '.' ['0'-'9']+ '.' ['0'-'9']+ '.' ['0'-'9']+) as contents
 let ipv6 = (['0'-'9' 'a'-'f' 'A'-'F' ':']+) as contents
 
+let zone_id = (['0'-'9' 'a'-'z' 'A'-'Z' '.' ]+) as contents
+
 (* inspired by https://github.com/tailhook/resolv-conf/blob/master/src/grammar.rs *)
 
 rule lex = parse
   | "nameserver" { SNAMESERVER }
-  | "options" ([^'\n']*) '\n' { EOL }
-  | "search" ([^'\n']*) '\n' { EOL }
-  | "domain" ([^'\n']*) '\n' { EOL }
-  | "sortlist" ([^'\n']*) '\n' { EOL }
-  | "lookup" ([^'\n']*) '\n' { EOL }
-  | "family" ([^'\n']*) '\n' { EOL }
+  | "options" ([^'\n']*) '\n' { state.lineno <- state.lineno + 1 ; EOL }
+  | "search" ([^'\n']*) '\n' { state.lineno <- state.lineno + 1 ; EOL }
+  | "domain" ([^'\n']*) '\n' { state.lineno <- state.lineno + 1 ; EOL }
+  | "sortlist" ([^'\n']*) '\n' { state.lineno <- state.lineno + 1 ; EOL }
+  | "lookup" ([^'\n']*) '\n' { state.lineno <- state.lineno + 1 ; EOL }
+  | "family" ([^'\n']*) '\n' { state.lineno <- state.lineno + 1 ; EOL }
   | [' ' '\t']+ { SPACE }
   | ipv4 { IPV4 contents }
   | ipv6 { IPV6 contents }
   | '.' { DOT }
   | ':' { COLON }
-  | [' ' '\t']* ('#' [^'\n']*)? '\n' { EOL }
-  | [' ' '\t']* (';' [^'\n']*)? '\n' { EOL }
+  | '%' { PERCENT }
+  | [' ' '\t']* ('#' [^'\n']*)? '\n' { state.lineno <- state.lineno + 1 ; EOL }
+  | [' ' '\t']* (';' [^'\n']*)? '\n' { state.lineno <- state.lineno + 1 ; EOL }
+  | zone_id { ZONE_ID contents }
   | eof { EOF }

--- a/resolvconf/resolvconf_parser.mly
+++ b/resolvconf/resolvconf_parser.mly
@@ -7,8 +7,10 @@
 %token SNAMESERVER
 %token DOT
 %token COLON
+%token PERCENT
 %token <string> IPV4
 %token <string> IPV6
+%token <string> ZONE_ID
 
 %start resolvconf
 %type <[ `Nameserver of Ipaddr.t ] list> resolvconf
@@ -26,7 +28,9 @@ s: SPACE {} | s SPACE {}
 
 ipv4: IPV4 { Ipaddr.V4.of_string_exn $1 }
 
-ipv6: IPV6 { Ipaddr.V6.of_string_exn $1 }
+ipv6:
+ IPV6 { Ipaddr.V6.of_string_exn $1 }
+ | IPV6 PERCENT ZONE_ID { Ipaddr.V6.of_string_exn $1 }
 
 nameserver:
  SNAMESERVER s ipv4 { `Nameserver (Ipaddr.V4 $3) }

--- a/resolvconf/resolvconf_state.ml
+++ b/resolvconf/resolvconf_state.ml
@@ -1,0 +1,11 @@
+(* State variables for the parser & lexer *)
+type parserstate = {
+  mutable lineno : int ;
+}
+
+let state = {
+  lineno = 1 ;
+}
+
+let reset () =
+  state.lineno <- 1

--- a/test/resolvconf.ml
+++ b/test/resolvconf.ml
@@ -87,11 +87,31 @@ nameserver 8.8.8.8
 nameserver 8.8.4.4
 |}
 
+let nixos =
+  {|
+nameserver fe80::c2d7:aaff:fe96:8d82%wlp3s0
+|}
+
+let nixos2 =
+  {|
+nameserver 8.8.8.8
+nameserver 8.8.4.4
+nameserver fe80::c2d7:aaff:fe96:8d82%wlp3s0
+nameserver 8.8.8.8
+nameserver 8.8.4.4
+|}
+
+let local_ns = [ "fe80::c2d7:aaff:fe96:8d82" ]
+
 let tests = [
   "linux", `Quick, test_one "linux" (linux, ok_result (v6_ns @ v4_ns)) ;
   "macos", `Quick, test_one "macos" (macos, ok_result (v6_ns @ v4_ns)) ;
   "openbsd", `Quick, test_one "openbsd" (openbsd, ok_result v4_ns) ;
   "simple", `Quick, test_one "simple" (simple, ok_result v4_ns) ;
+  "nixos", `Quick, test_one "nixos (with zone index)"
+    (nixos, ok_result local_ns) ;
+  "nixos 2", `Quick, test_one "nixos 2 (with zone index)"
+    (nixos2, ok_result (v4_ns @ local_ns @ v4_ns)) ;
 ]
 
 let () = Alcotest.run "DNS resolvconf tests" [ "resolvconf tests", tests ]


### PR DESCRIPTION
Inspired by the bug report in #328 by @bikallem, test case taken from there

@bikallem please let me know what you think of this PR, thanks.