### PR TITLE
Minor correction of the dependency constraints

### DIFF
--- a/dns-client-lwt.opam
+++ b/dns-client-lwt.opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "dune" {>="2.0.0"}
   "ocaml" {>= "4.08.0"}
-  "dns-client" {>= version}
+  "dns-client" {= version}
   "dns" {= version}
   "ipaddr" {>= "5.3.0"}
   "lwt" {>= "4.2.1"}


### PR DESCRIPTION
Given `dns {= version}` is already there, this doesn't change the behaviour at all but simply makes it clearer