### PR TITLE
Directly use Happy_eyeballs_lwt instead of a copy of it

### DIFF
--- a/app/odns.ml
+++ b/app/odns.ml
@@ -36,7 +36,8 @@ let pp_nameserver ppf = function
       ((Tls.Config.of_client tls_cfg).Tls.Config.peer_name)
 
 let do_a nameservers domains () =
-  let t = Dns_client_lwt.create ?nameservers () in
+  let happy_eyeballs = Happy_eyeballs_lwt.create () in
+  let t = Dns_client_lwt.create ?nameservers happy_eyeballs in
   let (_, ns) = Dns_client_lwt.nameservers t in
   Logs.info (fun m -> m "querying NS %a for A records of %a"
                 pp_nameserver (List.hd ns) Fmt.(list ~sep:(any ", ") Domain_name.pp) domains);
@@ -65,7 +66,8 @@ let for_all_domains nameservers ~domains typ f =
   (* [for_all_domains] is a utility function that lets us avoid duplicating
      this block of code in all the subcommands.
      We leave {!do_a} simple to provide a more readable example. *)
-  let t = Dns_client_lwt.create ?nameservers () in
+  let happy_eyeballs = Happy_eyeballs_lwt.create () in
+  let t = Dns_client_lwt.create ?nameservers happy_eyeballs in
   let _, ns = Dns_client_lwt.nameservers t in
   Logs.info (fun m -> m "NS: %a" pp_nameserver (List.hd ns));
   let open Lwt in

--- a/app/odns.ml
+++ b/app/odns.ml
@@ -36,8 +36,7 @@ let pp_nameserver ppf = function
       ((Tls.Config.of_client tls_cfg).Tls.Config.peer_name)
 
 let do_a nameservers domains () =
-  let he = Happy_eyeballs_lwt.create () in
-  let t = Dns_client_lwt.create ?nameservers he in
+  let t = Dns_client_lwt.create ?nameservers () in
   let (_, ns) = Dns_client_lwt.nameservers t in
   Logs.info (fun m -> m "querying NS %a for A records of %a"
                 pp_nameserver (List.hd ns) Fmt.(list ~sep:(any ", ") Domain_name.pp) domains);
@@ -66,8 +65,7 @@ let for_all_domains nameservers ~domains typ f =
   (* [for_all_domains] is a utility function that lets us avoid duplicating
      this block of code in all the subcommands.
      We leave {!do_a} simple to provide a more readable example. *)
-  let he = Happy_eyeballs_lwt.create () in
-  let t = Dns_client_lwt.create ?nameservers he in
+  let t = Dns_client_lwt.create ?nameservers () in
   let _, ns = Dns_client_lwt.nameservers t in
   Logs.info (fun m -> m "NS: %a" pp_nameserver (List.hd ns));
   let open Lwt in

--- a/app/odns.ml
+++ b/app/odns.ml
@@ -36,7 +36,8 @@ let pp_nameserver ppf = function
       ((Tls.Config.of_client tls_cfg).Tls.Config.peer_name)
 
 let do_a nameservers domains () =
-  let t = Dns_client_lwt.create ?nameservers () in
+  let he = Happy_eyeballs_lwt.create () in
+  let t = Dns_client_lwt.create ?nameservers he in
   let (_, ns) = Dns_client_lwt.nameservers t in
   Logs.info (fun m -> m "querying NS %a for A records of %a"
                 pp_nameserver (List.hd ns) Fmt.(list ~sep:(any ", ") Domain_name.pp) domains);
@@ -65,7 +66,8 @@ let for_all_domains nameservers ~domains typ f =
   (* [for_all_domains] is a utility function that lets us avoid duplicating
      this block of code in all the subcommands.
      We leave {!do_a} simple to provide a more readable example. *)
-  let t = Dns_client_lwt.create ?nameservers () in
+  let he = Happy_eyeballs_lwt.create () in
+  let t = Dns_client_lwt.create ?nameservers he in
   let _, ns = Dns_client_lwt.nameservers t in
   Logs.info (fun m -> m "NS: %a" pp_nameserver (List.hd ns));
   let open Lwt in

--- a/app/odnssec.ml
+++ b/app/odnssec.ml
@@ -24,7 +24,8 @@ let jump () hostname typ ns =
         | None -> None
         | Some ip -> Some (`Tcp, [ `Plaintext (ip, 53) ])
       in
-      let t = Dns_client_lwt.create ?nameservers ~edns:(`Manual edns) () in
+      let he = Happy_eyeballs_lwt.create () in
+      let t = Dns_client_lwt.create ?nameservers ~edns:(`Manual edns) he in
       let (_, ns) = Dns_client_lwt.nameservers t in
       Logs.info (fun m -> m "querying NS %a for A records of %a"
                     pp_nameserver (List.hd ns) Domain_name.pp hostname);

--- a/app/odnssec.ml
+++ b/app/odnssec.ml
@@ -24,7 +24,8 @@ let jump () hostname typ ns =
         | None -> None
         | Some ip -> Some (`Tcp, [ `Plaintext (ip, 53) ])
       in
-      let t = Dns_client_lwt.create ?nameservers ~edns:(`Manual edns) () in
+      let happy_eyeballs = Happy_eyeballs_lwt.create () in
+      let t = Dns_client_lwt.create ?nameservers ~edns:(`Manual edns) happy_eyeballs in
       let (_, ns) = Dns_client_lwt.nameservers t in
       Logs.info (fun m -> m "querying NS %a for A records of %a"
                     pp_nameserver (List.hd ns) Domain_name.pp hostname);

--- a/app/odnssec.ml
+++ b/app/odnssec.ml
@@ -24,8 +24,7 @@ let jump () hostname typ ns =
         | None -> None
         | Some ip -> Some (`Tcp, [ `Plaintext (ip, 53) ])
       in
-      let he = Happy_eyeballs_lwt.create () in
-      let t = Dns_client_lwt.create ?nameservers ~edns:(`Manual edns) he in
+      let t = Dns_client_lwt.create ?nameservers ~edns:(`Manual edns) () in
       let (_, ns) = Dns_client_lwt.nameservers t in
       Logs.info (fun m -> m "querying NS %a for A records of %a"
                     pp_nameserver (List.hd ns) Domain_name.pp hostname);

--- a/client/dns_client.ml
+++ b/client/dns_client.ml
@@ -222,6 +222,8 @@ struct
     stack : Transport.stack;
   }
 
+  let transport { transport ; _ } = transport
+
   (* TODO eventually use Auto, and retry without on FormErr *)
   let create ?(cache_size = 32) ?(edns = `None) ?nameservers ?(timeout = Duration.of_sec 5) stack =
     { cache = Dns_cache.empty cache_size ;
@@ -229,8 +231,6 @@ struct
       edns ;
       stack ;
     }
-
-  let stack { stack ; _ } = stack
 
   let nameservers { transport; _ } = Transport.nameservers transport
 

--- a/client/dns_client.ml
+++ b/client/dns_client.ml
@@ -219,7 +219,6 @@ struct
     mutable cache : Dns_cache.t ;
     transport : Transport.t ;
     edns : [ `None | `Auto | `Manual of Dns.Edns.t ] ;
-    stack : Transport.stack;
   }
 
   let transport { transport ; _ } = transport
@@ -229,7 +228,6 @@ struct
     { cache = Dns_cache.empty cache_size ;
       transport = Transport.create ?nameservers ~timeout stack ;
       edns ;
-      stack ;
     }
 
   let nameservers { transport; _ } = Transport.nameservers transport

--- a/client/dns_client.ml
+++ b/client/dns_client.ml
@@ -219,6 +219,7 @@ struct
     mutable cache : Dns_cache.t ;
     transport : Transport.t ;
     edns : [ `None | `Auto | `Manual of Dns.Edns.t ] ;
+    stack : Transport.stack;
   }
 
   (* TODO eventually use Auto, and retry without on FormErr *)
@@ -226,7 +227,10 @@ struct
     { cache = Dns_cache.empty cache_size ;
       transport = Transport.create ?nameservers ~timeout stack ;
       edns ;
+      stack ;
     }
+
+  let stack { stack ; _ } = stack
 
   let nameservers { transport; _ } = Transport.nameservers transport
 

--- a/client/dns_client.mli
+++ b/client/dns_client.mli
@@ -80,6 +80,9 @@ sig
       [`Auto] adds TCP Keepalive if protocol is TCP, [`Manual edns] adds the
       EDNS data specified. *)
 
+  val stack : t -> T.stack
+  (** [stack t] is the used stack by [t]. *)
+
   val nameservers : t -> Dns.proto * T.io_addr list
   (** [nameservers state] returns the list of nameservers to be used. *)
 

--- a/client/dns_client.mli
+++ b/client/dns_client.mli
@@ -66,6 +66,10 @@ module Make : functor (T : S) ->
 sig
 
   type t
+  (** The abstract type of a DNS client. *)
+
+  val transport : t -> T.t
+  (** [transport t] is the transport of [t]. *)
 
   val create : ?cache_size:int ->
     ?edns:[ `None | `Auto | `Manual of Dns.Edns.t ] ->
@@ -79,9 +83,6 @@ sig
       by [~edns] (defaults to [`None]): if [None], no EDNS will be present,
       [`Auto] adds TCP Keepalive if protocol is TCP, [`Manual edns] adds the
       EDNS data specified. *)
-
-  val stack : t -> T.stack
-  (** [stack t] is the used stack by [t]. *)
 
   val nameservers : t -> Dns.proto * T.io_addr list
   (** [nameservers state] returns the list of nameservers to be used. *)

--- a/dns-client-lwt.opam
+++ b/dns-client-lwt.opam
@@ -21,7 +21,7 @@ depends: [
   "lwt" {>= "4.2.1"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng-lwt" {>= "0.11.0"}
-  "happy-eyeballs" {>= "0.6.0"}
+  "happy-eyeballs-lwt" {>= "0.6.0"}
   "tls-lwt" {>= "0.16.0"}
   "ca-certs"
 ]
@@ -29,3 +29,6 @@ synopsis: "DNS client API using lwt"
 description: """
 A client implementation using uDNS and lwt for side effects.
 """
+pin-depends: [
+  [ "happy-eyeballs-lwt.dev" "git+https://github.com/dinosaure/happy-eyeballs.git#84e340ac3c3442f1693a59a0ff8f2465880b933d" ]
+]

--- a/dns-client-lwt.opam
+++ b/dns-client-lwt.opam
@@ -30,6 +30,6 @@ description: """
 A client implementation using uDNS and lwt for side effects.
 """
 pin-depends: [
-  [ "happy-eyeballs-lwt.dev" "git+https://github.com/dinosaure/happy-eyeballs.git#c6bbca167eb036ba2d4d8888da250ab6c04b6b79" ]
-  [ "happy-eyeballs.dev" "git+https://github.com/dinosaure/happy-eyeballs.git#c6bbca167eb036ba2d4d8888da250ab6c04b6b79" ]
+  [ "happy-eyeballs-lwt.dev" "git+https://github.com/dinosaure/happy-eyeballs.git#a0ae36741eebfc425faf95c7fb4f7e03463e213c" ]
+  [ "happy-eyeballs.dev" "git+https://github.com/dinosaure/happy-eyeballs.git#a0ae36741eebfc425faf95c7fb4f7e03463e213c" ]
 ]

--- a/dns-client-lwt.opam
+++ b/dns-client-lwt.opam
@@ -30,5 +30,6 @@ description: """
 A client implementation using uDNS and lwt for side effects.
 """
 pin-depends: [
-  [ "happy-eyeballs-lwt.dev" "git+https://github.com/dinosaure/happy-eyeballs.git#84e340ac3c3442f1693a59a0ff8f2465880b933d" ]
+  [ "happy-eyeballs-lwt.dev" "git+https://github.com/dinosaure/happy-eyeballs.git#c6bbca167eb036ba2d4d8888da250ab6c04b6b79" ]
+  [ "happy-eyeballs.dev" "git+https://github.com/dinosaure/happy-eyeballs.git#c6bbca167eb036ba2d4d8888da250ab6c04b6b79" ]
 ]

--- a/dns-client-lwt.opam
+++ b/dns-client-lwt.opam
@@ -22,6 +22,7 @@ depends: [
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng-lwt" {>= "0.11.0"}
   "happy-eyeballs-lwt" {>= "1.0.0"}
+  "happy-eyeballs" {>= "1.0.0"}
   "tls-lwt" {>= "0.16.0"}
   "ca-certs"
 ]

--- a/dns-client-lwt.opam
+++ b/dns-client-lwt.opam
@@ -21,7 +21,7 @@ depends: [
   "lwt" {>= "4.2.1"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng-lwt" {>= "0.11.0"}
-  "happy-eyeballs-lwt" {>= "0.6.0"}
+  "happy-eyeballs-lwt" {>= "1.0.0"}
   "tls-lwt" {>= "0.16.0"}
   "ca-certs"
 ]
@@ -29,7 +29,3 @@ synopsis: "DNS client API using lwt"
 description: """
 A client implementation using uDNS and lwt for side effects.
 """
-pin-depends: [
-  [ "happy-eyeballs-lwt.dev" "git+https://github.com/dinosaure/happy-eyeballs.git#a0ae36741eebfc425faf95c7fb4f7e03463e213c" ]
-  [ "happy-eyeballs.dev" "git+https://github.com/dinosaure/happy-eyeballs.git#a0ae36741eebfc425faf95c7fb4f7e03463e213c" ]
-]

--- a/dns-client-lwt.opam
+++ b/dns-client-lwt.opam
@@ -21,7 +21,7 @@ depends: [
   "lwt" {>= "4.2.1"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng-lwt" {>= "0.11.0"}
-  "happy-eyeballs-lwt" {>= "1.0.0"}
+  "happy-eyeballs-lwt" {>= "1.1.0"}
   "happy-eyeballs" {>= "1.0.0"}
   "tls-lwt" {>= "0.16.0"}
   "ca-certs"

--- a/dns-client-mirage.opam
+++ b/dns-client-mirage.opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "happy-eyeballs" {>= "0.6.0"}
+  "happy-eyeballs-mirage" {>= "1.0.0"}
   "tls-mirage" {>= "0.16.0"}
   "x509" {>= "0.16.0"}
   "ca-certs-nss"

--- a/dns-client-mirage.opam
+++ b/dns-client-mirage.opam
@@ -24,6 +24,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "happy-eyeballs-mirage" {>= "1.0.0"}
+  "happy-eyeballs" {>= "1.0.0"}
   "tls-mirage" {>= "0.16.0"}
   "x509" {>= "0.16.0"}
   "ca-certs-nss"

--- a/dns-client-mirage.opam
+++ b/dns-client-mirage.opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "happy-eyeballs-mirage" {>= "1.0.0"}
+  "happy-eyeballs-mirage" {>= "1.1.0"}
   "happy-eyeballs" {>= "1.0.0"}
   "tls-mirage" {>= "0.16.0"}
   "x509" {>= "0.16.0"}

--- a/lwt/client/dns_client_lwt.ml
+++ b/lwt/client/dns_client_lwt.ml
@@ -143,15 +143,14 @@ module Transport : Dns_client.S
       let happy_eyeballs = Happy_eyeballs.create ~connect_timeout:timeout (clock ()) in
       Happy_eyeballs_lwt.create ~happy_eyeballs ()
     in
-    let t = {
+    {
       nameservers ;
       timeout_ns = timeout ;
       fd = None ;
       connected_condition = None ;
       requests = IM.empty ;
       he ;
-    } in
-    t
+    }
 
   let nameservers { nameservers; _ } = `Tcp, nameserver_ips nameservers
 

--- a/lwt/client/dns_client_lwt.ml
+++ b/lwt/client/dns_client_lwt.ml
@@ -48,8 +48,6 @@ module Transport : Dns_client.S
 
   let clock = Mtime_clock.elapsed_ns
 
-  let he_timer_interval = Duration.of_ms 10
-
   let close_socket fd =
     Lwt.catch (fun () -> Lwt_unix.close fd) (fun _ -> Lwt.return_unit)
 

--- a/lwt/client/dns_client_lwt.mli
+++ b/lwt/client/dns_client_lwt.mli
@@ -16,3 +16,17 @@ module Transport : Dns_client.S
    and type stack = Happy_eyeballs_lwt.t
 
 include module type of Dns_client.Make(Transport)
+
+val create_happy_eyeballs :
+  ?cache_size:int ->
+  ?edns:[ `None | `Auto | `Manual of Dns.Edns.t ] ->
+  ?nameservers:(Dns.proto * Transport.io_addr list) ->
+  ?timeout:int64 ->
+  Happy_eyeballs_lwt.t ->
+  t * Happy_eyeballs_lwt.t
+(** [create_happy_eyeballs he] returns and inject the [ocaml-dns] implementation
+    into the given happy-eyeballs instance. By default, an happy-eyeballs
+    instance use the system DNS resolver (via {!val:Unix.getaddrinfo}). However,
+    the user is able to use the [ocaml-dns] implementation to resolve
+    domain-name. By this way, when the user wants to connect to a domain-name,
+    the happy-eyeballs instance will use the {!val:getaddrinfo} provided above. *)

--- a/lwt/client/dns_client_lwt.mli
+++ b/lwt/client/dns_client_lwt.mli
@@ -22,6 +22,6 @@ val create_happy_eyeballs :
   ?timer_interval:int64 ->
   t ->
   Happy_eyeballs_lwt.t
-(** [create_happy_eyeballs t] returns the happy-eyeballs instance used by the
+(** [create_happy_eyeballs dns] returns the happy-eyeballs instance used by the
     [dns] implementation, which uses the [dns] implementation for resolving
     hostnames. *)

--- a/lwt/client/dns_client_lwt.mli
+++ b/lwt/client/dns_client_lwt.mli
@@ -13,20 +13,15 @@
 module Transport : Dns_client.S
    with type io_addr = [ `Plaintext of Ipaddr.t * int | `Tls of Tls.Config.client * Ipaddr.t * int ]
    and type +'a io = 'a Lwt.t
-   and type stack = Happy_eyeballs_lwt.t
+   and type stack = unit
 
 include module type of Dns_client.Make(Transport)
 
 val create_happy_eyeballs :
-  ?cache_size:int ->
-  ?edns:[ `None | `Auto | `Manual of Dns.Edns.t ] ->
-  ?nameservers:(Dns.proto * Transport.io_addr list) ->
-  ?timeout:int64 ->
-  Happy_eyeballs_lwt.t ->
-  t * Happy_eyeballs_lwt.t
-(** [create_happy_eyeballs he] returns and inject the [ocaml-dns] implementation
-    into the given happy-eyeballs instance. By default, an happy-eyeballs
-    instance use the system DNS resolver (via {!val:Unix.getaddrinfo}). However,
-    the user is able to use the [ocaml-dns] implementation to resolve
-    domain-name. By this way, when the user wants to connect to a domain-name,
-    the happy-eyeballs instance will use the {!val:getaddrinfo} provided above. *)
+  ?happy_eyeballs:Happy_eyeballs.t ->
+  ?timer_interval:int64 ->
+  t ->
+  Happy_eyeballs_lwt.t
+(** [create_happy_eyeballs t] returns the happy-eyeballs instance used by the
+    [dns] implementation, which uses the [dns] implementation for resolving
+    hostnames. *)

--- a/lwt/client/dns_client_lwt.mli
+++ b/lwt/client/dns_client_lwt.mli
@@ -22,6 +22,6 @@ val create_happy_eyeballs :
   ?timer_interval:int64 ->
   t ->
   Happy_eyeballs_lwt.t
-(** [create_happy_eyeballs dns] returns the happy-eyeballs instance used by the
-    [dns] implementation, which uses the [dns] implementation for resolving
-    hostnames. *)
+(** [create_happy_eyeballs dns] creates a happy-eyeballs-lwt instance, where
+    resolving of hostnames uses [getaddrinfo] provided by the [dns]
+    implementation. *)

--- a/lwt/client/dns_client_lwt.mli
+++ b/lwt/client/dns_client_lwt.mli
@@ -13,6 +13,6 @@
 module Transport : Dns_client.S
    with type io_addr = [ `Plaintext of Ipaddr.t * int | `Tls of Tls.Config.client * Ipaddr.t * int ]
    and type +'a io = 'a Lwt.t
-   and type stack = unit
+   and type stack = Happy_eyeballs_lwt.t
 
 include module type of Dns_client.Make(Transport)

--- a/lwt/client/dns_client_lwt.mli
+++ b/lwt/client/dns_client_lwt.mli
@@ -13,15 +13,6 @@
 module Transport : Dns_client.S
    with type io_addr = [ `Plaintext of Ipaddr.t * int | `Tls of Tls.Config.client * Ipaddr.t * int ]
    and type +'a io = 'a Lwt.t
-   and type stack = unit
+   and type stack = Happy_eyeballs_lwt.t
 
 include module type of Dns_client.Make(Transport)
-
-val create_happy_eyeballs :
-  ?happy_eyeballs:Happy_eyeballs.t ->
-  ?timer_interval:int64 ->
-  t ->
-  Happy_eyeballs_lwt.t
-(** [create_happy_eyeballs dns] creates a happy-eyeballs-lwt instance, where
-    resolving of hostnames uses [getaddrinfo] provided by the [dns]
-    implementation. *)

--- a/lwt/client/dune
+++ b/lwt/client/dune
@@ -2,5 +2,5 @@
   (name        dns_client_lwt)
   (modules     dns_client_lwt)
   (public_name dns-client-lwt)
-  (libraries   lwt lwt.unix dns dns-client dns-client.resolvconf mtime.clock.os mirage-crypto-rng-lwt ipaddr.unix happy-eyeballs tls-lwt ca-certs)
+  (libraries   lwt lwt.unix dns dns-client dns-client.resolvconf mtime.clock.os mirage-crypto-rng-lwt ipaddr.unix happy-eyeballs happy-eyeballs-lwt tls-lwt ca-certs)
   (wrapped     false))

--- a/mirage/client/dns_client_mirage.ml
+++ b/mirage/client/dns_client_mirage.ml
@@ -325,7 +325,13 @@ The format of a nameserver is:
       let connected_condition = Lwt_condition.create () in
       t.connected_condition <- Some connected_condition ;
       let ns = to_pairs nameservers in
-      H.connect_ip t.he ns >>= function
+      (* The connect_timeout given here is a bit too much, since it should
+         be (a) connect to the remote NS (b) send query, receive answer.
+
+         At the moment, how this is done, is that we use the connect_timeout
+         for (a) and another separate one for (b). Since we do connection
+         pooling, it is slightly tricky to use only a single connect_timeout. *)
+      H.connect_ip ~connect_timeout:t.timeout_ns t.he ns >>= function
       | Error `Msg msg ->
         let err = Error (`Msg (Fmt.str "error %s connecting to resolver %a"
                                  msg

--- a/mirage/client/dns_client_mirage.ml
+++ b/mirage/client/dns_client_mirage.ml
@@ -29,7 +29,7 @@ module type S = sig
 
   val create_happy_eyeballs : ?aaaa_timeout:int64 -> ?connect_delay:int64 ->
     ?connect_timeout:int64 -> ?resolve_timeout:int64 -> ?resolve_retries:int ->
-    ?timer_interval:int64 -> t -> HE.t Lwt.t
+    ?timer_interval:int64 -> t -> HE.t
 end
 
 module Make (R : Mirage_random.S) (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (S : Tcpip.Stack.V4V6) = struct
@@ -456,6 +456,9 @@ The format of a nameserver is:
         Ipaddr.V6.Set.fold (fun ipv6 -> Ipaddr.Set.add (Ipaddr.V6 ipv6))
           set Ipaddr.Set.empty
     in
-    HE.connect_device ?aaaa_timeout ?connect_delay ?connect_timeout
-      ?resolve_timeout ?resolve_retries ?timer_interval ~getaddrinfo (stack t)
+    let happy_eyeballs =
+      Happy_eyeballs.create ?aaaa_timeout ?connect_delay ?connect_timeout
+        ?resolve_timeout ?resolve_retries (M.elapsed_ns ())
+    in
+    HE.create ~happy_eyeballs ~getaddrinfo ?timer_interval (stack t)
 end

--- a/mirage/client/dns_client_mirage.ml
+++ b/mirage/client/dns_client_mirage.ml
@@ -6,6 +6,8 @@ module Log = (val Logs.src_log src : Logs.LOG)
 module IM = Map.Make(Int)
 
 module type S = sig
+  module HE : Happy_eyeballs_mirage.S
+
   module Transport : Dns_client.S
     with type io_addr = [
         | `Plaintext of Ipaddr.t * int
@@ -24,6 +26,10 @@ module type S = sig
     ?nameservers:string list ->
     ?timeout:int64 ->
     Transport.stack -> t Lwt.t
+
+  val create_happy_eyeballs : ?aaaa_timeout:int64 -> ?connect_delay:int64 ->
+    ?connect_timeout:int64 -> ?resolve_timeout:int64 -> ?resolve_retries:int ->
+    ?timer_interval:int64 -> t -> HE.t Lwt.t
 end
 
 module Make (R : Mirage_random.S) (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (S : Tcpip.Stack.V4V6) = struct
@@ -106,6 +112,8 @@ The format of a nameserver is:
         Error (`Msg ("Unable to decode nameserver " ^ str))
     end |> Result.map_error (function `Msg e -> `Msg (e ^ format))
 
+  module HE = Happy_eyeballs_mirage.Make(T)(M)(S)
+
   module Transport : Dns_client.S
     with type stack = S.t
      and type +'a io = 'a Lwt.t
@@ -129,106 +137,11 @@ The format of a nameserver is:
       mutable flow : [`Plain of S.TCP.flow | `Tls of TLS.flow ] option ;
       mutable connected_condition : (unit, [ `Msg of string ]) result Lwt_condition.t option ;
       mutable requests : (Cstruct.t * (Cstruct.t, [ `Msg of string ]) result Lwt_condition.t) IM.t ;
-      mutable he : Happy_eyeballs.t ;
-      mutable cancel_connecting : (int * unit Lwt.u) list Happy_eyeballs.Waiter_map.t ;
-      mutable waiters : ((Ipaddr.t * int) * S.TCP.flow, [ `Msg of string ]) result Lwt.u Happy_eyeballs.Waiter_map.t ;
-      timer_condition : unit Lwt_condition.t ;
+      he : HE.t ;
     }
     type context = t
 
     let clock = M.elapsed_ns
-    let he_timer_interval = Duration.of_ms 10
-
-    let try_connect stack addr =
-      let open Lwt.Infix in
-      S.TCP.create_connection (S.tcp stack) addr >|=
-      Result.map_error
-        (fun err -> `Msg (Fmt.str "error connecting to nameserver %a:%u: %a"
-                            Ipaddr.pp (fst addr) (snd addr) S.TCP.pp_error err))
-
-    let handle_one_action t = function
-      | Happy_eyeballs.Connect (host, id, attempt, addr) ->
-        let cancelled, cancel = Lwt.task () in
-        let entry = attempt, cancel in
-        t.cancel_connecting <-
-          Happy_eyeballs.Waiter_map.update id
-            (function None -> Some [ entry ] | Some c -> Some (entry :: c))
-            t.cancel_connecting;
-        let conn =
-          try_connect t.stack addr >>= function
-          | Ok flow ->
-            let cancel_connecting, others =
-              Happy_eyeballs.Waiter_map.find_and_remove id t.cancel_connecting
-            in
-            t.cancel_connecting <- cancel_connecting;
-            List.iter (fun (att, u) -> if att <> attempt then Lwt.wakeup_later u ())
-              (Option.value ~default:[] others);
-            let waiters, r = Happy_eyeballs.Waiter_map.find_and_remove id t.waiters in
-            t.waiters <- waiters;
-            begin match r with
-              | Some waiter ->
-                Lwt.wakeup_later waiter (Ok (addr, flow));
-                Lwt.return_unit
-              | None -> S.TCP.close flow
-            end >|= fun () ->
-            Some (Happy_eyeballs.Connected (host, id, addr))
-          | Error `Msg msg ->
-            t.cancel_connecting <-
-              Happy_eyeballs.Waiter_map.update id
-                (function None -> None | Some c ->
-                  match List.filter (fun (att, _) -> not (att = attempt)) c with
-                  | [] -> None
-                  | c -> Some c)
-                t.cancel_connecting;
-            Lwt.return (Some (Happy_eyeballs.Connection_failed (host, id, addr, msg)))
-        in
-        Lwt.pick [ conn ; (cancelled >|= fun () -> None) ]
-      | Connect_failed (host, id, reason) ->
-        let cancel_connecting, others =
-          Happy_eyeballs.Waiter_map.find_and_remove id t.cancel_connecting
-        in
-        t.cancel_connecting <- cancel_connecting;
-        List.iter (fun (_, u) -> Lwt.wakeup_later u ()) (Option.value ~default:[] others);
-        let waiters, r = Happy_eyeballs.Waiter_map.find_and_remove id t.waiters in
-        t.waiters <- waiters;
-        begin match r with
-          | Some waiter ->
-            let err =
-              Fmt.str "connection to %a failed: %s" Domain_name.pp host reason
-            in
-            Lwt.wakeup_later waiter (Error (`Msg err))
-          | None -> ()
-        end;
-        Lwt.return None
-      | Resolve_a _ | Resolve_aaaa _ as a ->
-        Log.warn (fun m -> m "ignoring action %a" Happy_eyeballs.pp_action a);
-        Lwt.return None
-
-    let rec handle_action t action =
-      handle_one_action t action >>= function
-      | None -> Lwt.return_unit
-      | Some event ->
-        let he, actions = Happy_eyeballs.event t.he (clock ()) event in
-        t.he <- he;
-        Lwt_list.iter_p (handle_action t) actions
-
-    let handle_timer_actions t actions =
-      Lwt.async (fun () -> Lwt_list.iter_p (fun a -> handle_action t a) actions)
-
-    let rec he_timer t =
-      let open Lwt.Infix in
-      let rec loop () =
-        let he, cont, actions = Happy_eyeballs.timer t.he (clock ()) in
-        t.he <- he ;
-        handle_timer_actions t actions ;
-        match cont with
-        | `Suspend -> he_timer t
-        | `Act ->
-          T.sleep_ns he_timer_interval >>= fun () ->
-          loop ()
-      in
-      Lwt_condition.wait t.timer_condition >>= fun () ->
-      loop ()
 
     let read_udp t ip ip_us ~src ~dst ~src_port:_ data =
       if Ipaddr.compare ip_us dst = 0 && Ipaddr.compare ip src = 0 &&
@@ -272,7 +185,11 @@ The format of a nameserver is:
           `Tcp, ns
         | Some (a, ns) -> a, ns
       in
-      let t = {
+      let he =
+        let happy_eyeballs = Happy_eyeballs.create ~connect_timeout:timeout (clock ()) in
+        HE.create ~happy_eyeballs stack
+      in
+      {
         nameservers ;
         proto ;
         timeout_ns = timeout ;
@@ -281,14 +198,8 @@ The format of a nameserver is:
         flow = None ;
         connected_condition = None ;
         requests = IM.empty ;
-        he = Happy_eyeballs.create ~connect_timeout:timeout (clock ()) ;
-        cancel_connecting = Happy_eyeballs.Waiter_map.empty ;
-        waiters = Happy_eyeballs.Waiter_map.empty ;
-        timer_condition = Lwt_condition.create () ;
-      } in
-      match proto with
-      | `Tcp -> Lwt.async (fun () -> he_timer t); t
-      | `Udp -> t
+        he ;
+      }
 
     let nameservers { proto ; nameservers ; _ } = proto, nameservers
     let rng = R.generate ?g:None
@@ -395,15 +306,8 @@ The format of a nameserver is:
     let rec connect_ns t nameservers =
       let connected_condition = Lwt_condition.create () in
       t.connected_condition <- Some connected_condition ;
-      let waiter, notify = Lwt.task () in
-      let waiters, id = Happy_eyeballs.Waiter_map.register notify t.waiters in
-      t.waiters <- waiters;
       let ns = to_pairs nameservers in
-      let he, actions = Happy_eyeballs.connect_ip t.he (clock ()) ~id ns in
-      t.he <- he;
-      Lwt_condition.signal t.timer_condition ();
-      Lwt.async (fun () -> Lwt_list.iter_p (handle_action t) actions);
-      waiter >>= function
+      HE.connect_ip t.he ns >>= function
       | Error `Msg msg ->
         let err = Error (`Msg (Fmt.str "error %s connecting to resolver %a"
                                  msg
@@ -537,4 +441,21 @@ The format of a nameserver is:
       | _::_, _ -> Some (`Tcp, tcp)
     in
     Lwt.return (create ?cache_size ?edns ?nameservers ?timeout stack)
+
+  let create_happy_eyeballs ?aaaa_timeout ?connect_delay ?connect_timeout
+      ?resolve_timeout ?resolve_retries ?timer_interval t =
+    let getaddrinfo record domain_name =
+      let open Lwt_result.Infix in
+      match record with
+      | `A ->
+        getaddrinfo t Dns.Rr_map.A domain_name >|= fun (_ttl, set) ->
+        Ipaddr.V4.Set.fold (fun ipv4 -> Ipaddr.Set.add (Ipaddr.V4 ipv4))
+          set Ipaddr.Set.empty
+      | `AAAA ->
+        getaddrinfo t Dns.Rr_map.Aaaa domain_name >|= fun (_ttl, set) ->
+        Ipaddr.V6.Set.fold (fun ipv6 -> Ipaddr.Set.add (Ipaddr.V6 ipv6))
+          set Ipaddr.Set.empty
+    in
+    HE.connect_device ?aaaa_timeout ?connect_delay ?connect_timeout
+      ?resolve_timeout ?resolve_retries ?timer_interval ~getaddrinfo (stack t)
 end

--- a/mirage/client/dns_client_mirage.mli
+++ b/mirage/client/dns_client_mirage.mli
@@ -47,7 +47,7 @@ module type S = sig
 
   val create_happy_eyeballs : ?aaaa_timeout:int64 -> ?connect_delay:int64 ->
     ?connect_timeout:int64 -> ?resolve_timeout:int64 -> ?resolve_retries:int ->
-    ?timer_interval:int64 -> t -> HE.t Lwt.t
+    ?timer_interval:int64 -> t -> HE.t
   (** [create_happy_eyeballs ~aaaa_timeout ~connect_delay ~connect_timeout ~resolve_timeout ~resolve_retries ~timer_interval dns]
       is a happy_eyeballs value where [dns] is used for resolving hostnames. *)
 end

--- a/mirage/client/dns_client_mirage.mli
+++ b/mirage/client/dns_client_mirage.mli
@@ -1,4 +1,7 @@
 module type S = sig
+
+  module HE : Happy_eyeballs_mirage.S
+
   module Transport : Dns_client.S
     with type io_addr = [
         | `Plaintext of Ipaddr.t * int
@@ -40,7 +43,13 @@ module type S = sig
 
       @raise [Invalid_argument] if given strings don't respect formats explained
       by {!nameserver_of_string}.
-   *)
+  *)
+
+  val create_happy_eyeballs : ?aaaa_timeout:int64 -> ?connect_delay:int64 ->
+    ?connect_timeout:int64 -> ?resolve_timeout:int64 -> ?resolve_retries:int ->
+    ?timer_interval:int64 -> t -> HE.t Lwt.t
+  (** [create_happy_eyeballs ~aaaa_timeout ~connect_delay ~connect_timeout ~resolve_timeout ~resolve_retries ~timer_interval dns]
+      is a happy_eyeballs value where [dns] is used for resolving hostnames. *)
 end
 
 module Make (R : Mirage_random.S) (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (S : Tcpip.Stack.V4V6) : S with type Transport.stack = S.t

--- a/mirage/client/dns_client_mirage.mli
+++ b/mirage/client/dns_client_mirage.mli
@@ -36,7 +36,7 @@ module type S = sig
     ?edns:[ `None | `Auto | `Manual of Dns.Edns.t ] ->
     ?nameservers:string list ->
     ?timeout:int64 ->
-    ?happy_eyeballs:happy_eyeballs ->
+    happy_eyeballs:happy_eyeballs ->
     stack -> t Lwt.t
   (** [connect ?cache_size ?edns ?nameservers ?timeout ?happy_eyeballs stack]
       creates a DNS entity which is able to resolve domain-name. It expects
@@ -63,5 +63,5 @@ module Make
   (H : Happy_eyeballs_mirage.S with type stack = S.t
                                 and type flow = S.TCP.flow)
   : S with type stack = S.t
-       and type Transport.stack = S.t * H.t option
+       and type Transport.stack = S.t * H.t
        and type happy_eyeballs = H.t

--- a/mirage/client/dns_client_mirage.mli
+++ b/mirage/client/dns_client_mirage.mli
@@ -1,6 +1,5 @@
 module type S = sig
   type happy_eyeballs
-  type stack
 
   module Transport :
     sig
@@ -36,16 +35,14 @@ module type S = sig
     ?edns:[ `None | `Auto | `Manual of Dns.Edns.t ] ->
     ?nameservers:string list ->
     ?timeout:int64 ->
-    happy_eyeballs:happy_eyeballs ->
-    stack -> t Lwt.t
-  (** [connect ?cache_size ?edns ?nameservers ?timeout ?happy_eyeballs stack]
+    Transport.stack -> t Lwt.t
+  (** [connect ?cache_size ?edns ?nameservers ?timeout (stack, happy_eyeballs)]
       creates a DNS entity which is able to resolve domain-name. It expects
       few optional arguments:
       - [cache_size] the size of the LRU cache,
       - [edns] the behaviour of whether or not to send edns in queries,
       - [nameservers] a list of {i nameservers} used to resolve domain-names,
-      - [timeout] (in nanoseconds), passed to {create},
-      - [happy_eyeballs] an instance of happy eyeballs to use.
+      - [timeout] (in nanoseconds), passed to {create}.
 
       The provided [happy_eyeballs] will use [t] for resolving hostnames.
 
@@ -62,6 +59,5 @@ module Make
   (S : Tcpip.Stack.V4V6)
   (H : Happy_eyeballs_mirage.S with type stack = S.t
                                 and type flow = S.TCP.flow)
-  : S with type stack = S.t
-       and type Transport.stack = S.t * H.t
+  : S with type Transport.stack = S.t * H.t
        and type happy_eyeballs = H.t

--- a/mirage/client/dune
+++ b/mirage/client/dune
@@ -1,5 +1,5 @@
 (library
   (name        dns_client_mirage)
   (public_name dns-client-mirage)
-  (libraries   domain-name ipaddr mirage-random mirage-time tcpip mirage-clock dns-client happy-eyeballs tls-mirage ca-certs-nss)
+  (libraries   domain-name ipaddr mirage-random mirage-time tcpip mirage-clock dns-client happy-eyeballs happy-eyeballs-mirage tls-mirage ca-certs-nss)
   (wrapped     false))

--- a/mirage/stub/dns_stub_mirage.ml
+++ b/mirage/stub/dns_stub_mirage.ml
@@ -58,7 +58,8 @@ module Make (R : Mirage_random.S) (T : Mirage_time.S) (P : Mirage_clock.PCLOCK) 
     let metrics = Dns.counter_metrics ~f "stub-resolver" in
     (fun x -> Metrics.add metrics (fun x -> x) (fun d -> d x))
 
-  module Client = Dns_client_mirage.Make(R)(T)(C)(P)(S)
+  module H = Happy_eyeballs_mirage.Make(T)(C)(S)
+  module Client = Dns_client_mirage.Make(R)(T)(C)(P)(S)(H)
 
   (* likely this should contain:
      - a primary server (handling updates)

--- a/mirage/stub/dns_stub_mirage.ml
+++ b/mirage/stub/dns_stub_mirage.ml
@@ -234,7 +234,7 @@ module Make (R : Mirage_random.S) (T : Mirage_time.S) (P : Mirage_clock.PCLOCK) 
         | None -> resolve t packet.Packet.question packet.Packet.data build_reply
 
   let create ?(cache_size = 10000) ?edns ?nameservers ?timeout ?(on_update = fun ~old:_ ?authenticated_key:_ ~update_source:_ _trie -> Lwt.return_unit) primary ~happy_eyeballs stack =
-    Client.connect ~cache_size ?edns ?nameservers ?timeout ~happy_eyeballs stack >|= fun client ->
+    Client.connect ~cache_size ?edns ?nameservers ?timeout (stack, happy_eyeballs) >|= fun client ->
     let server = Dns_server.Primary.server primary in
     let reserved = Dns_server.create Dns_resolver_root.reserved R.generate in
     let t = { client ; reserved ; server ; on_update } in

--- a/mirage/stub/dns_stub_mirage.ml
+++ b/mirage/stub/dns_stub_mirage.ml
@@ -233,8 +233,8 @@ module Make (R : Mirage_random.S) (T : Mirage_time.S) (P : Mirage_clock.PCLOCK) 
         | Some data -> metrics `Reserved_answers ; Lwt.return (Some data)
         | None -> resolve t packet.Packet.question packet.Packet.data build_reply
 
-  let create ?(cache_size = 10000) ?edns ?nameservers ?timeout ?(on_update = fun ~old:_ ?authenticated_key:_ ~update_source:_ _trie -> Lwt.return_unit) primary stack =
-    Client.connect ~cache_size ?edns ?nameservers ?timeout stack >|= fun client ->
+  let create ?(cache_size = 10000) ?edns ?nameservers ?timeout ?(on_update = fun ~old:_ ?authenticated_key:_ ~update_source:_ _trie -> Lwt.return_unit) primary ~happy_eyeballs stack =
+    Client.connect ~cache_size ?edns ?nameservers ?timeout ~happy_eyeballs stack >|= fun client ->
     let server = Dns_server.Primary.server primary in
     let reserved = Dns_server.create Dns_resolver_root.reserved R.generate in
     let t = { client ; reserved ; server ; on_update } in


### PR DESCRIPTION
This commit delete a dependency cycle between happy-eyeballs, happy-eyeballs-lwt, dns and dns-client-lwt. The basic happy-eyeballs-lwt implementation is not able yet to resolve domain-name but the user can inject a getaddrinfo which may come from dns-client-lwt. The idea is: 1) create a happy-eyeballs-lwt instance
2) create a dns-client-lwt instance
3) inject Dns_client_lwt.getaddrinfo into our happy-eyeballs-lwt
   instance

This patch delete a duplicate code about happy-eyeballs implementations.

Related to robur-coop/happy-eyeballs#38