### PR TITLE
secondary server, mirage layer

### DIFF
--- a/mirage/server/dns_server_mirage.ml
+++ b/mirage/server/dns_server_mirage.ml
@@ -195,7 +195,7 @@ module Make (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (TIME : Mirage_t
       Dns.read_tcp f >>= function
       | Error () ->
         Log.debug (fun m -> m "removing %a from tcp_out" Ipaddr.pp ip) ;
-        close ~timer:false ip
+        close ~timer ip
       | Ok data ->
         inc `Tcp_query;
         let now = Ptime.v (P.now_d_ps ()) in
@@ -211,7 +211,7 @@ module Make (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (TIME : Mirage_t
            Dns.send_tcp (Dns.flow f) x >>= function
            | Error () ->
              Log.debug (fun m -> m "removing %a from tcp_out" Ipaddr.pp ip) ;
-             close ~timer:false ip >|= fun () -> Error ()
+             close ~timer ip >|= fun () -> Error ()
            | Ok () -> Lwt.return (Ok ())) >>= fun r ->
         (match out with
          | None -> Lwt.return_unit


### PR DESCRIPTION
If there's a (Dns_server.Secondary.)timer-triggered connection request, do not infinitely try to connect (via request -> fail -> close -> request) in a tight loop, but cancel on first sight (the timer is responsible for re-connecting)

I'm in the process of testing this in production.