### PR TITLE
dns_certify_mirage: use a pair instead of two separate arguments for the dns-key

### DIFF
--- a/mirage/certify/dns_certify_mirage.ml
+++ b/mirage/certify/dns_certify_mirage.ml
@@ -73,7 +73,7 @@ module Make (R : Mirage_crypto_rng_mirage.S) (P : Mirage_clock.PCLOCK) (TIME : M
         in
         wait_for_cert ()
 
-  let retrieve_certificate stack ~dns_key_name dns_key ~hostname ?(additional_hostnames = []) ?(key_type = `RSA) ?key_data ?key_seed ?bits dns port =
+  let retrieve_certificate stack (dns_key_name, dns_key) ~hostname ?(additional_hostnames = []) ?(key_type = `RSA) ?key_data ?key_seed ?bits dns port =
     let zone = Domain_name.(host_exn (drop_label_exn ~amount:2 dns_key_name)) in
     let not_sub subdomain = not (Domain_name.is_subdomain ~subdomain ~domain:zone) in
     if not_sub hostname then

--- a/mirage/certify/dns_certify_mirage.mli
+++ b/mirage/certify/dns_certify_mirage.mli
@@ -2,17 +2,17 @@
 module Make (R : Mirage_crypto_rng_mirage.S) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S) (S : Tcpip.Stack.V4V6) : sig
 
   val retrieve_certificate :
-    S.t -> dns_key_name:[`raw ] Domain_name.t -> Dns.Dnskey.t ->
+    S.t -> ([`raw ] Domain_name.t * Dns.Dnskey.t) ->
     hostname:[ `host ] Domain_name.t ->
     ?additional_hostnames:[ `raw ] Domain_name.t list ->
     ?key_type:X509.Key_type.t -> ?key_data:string -> ?key_seed:string ->
     ?bits:int -> S.TCP.ipaddr -> int ->
     (X509.Certificate.t list * X509.Private_key.t, [ `Msg of string ]) result Lwt.t
-  (** [retrieve_certificate stack ~dns_key_name dns_key ~hostname ~key_type ~key_data ~key_seed ~bits server_ip port]
+  (** [retrieve_certificate stack dns_key ~hostname ~key_type ~key_data ~key_seed ~bits server_ip port]
       generates a private key (using [key_type], [key_data], [key_seed], and
       [bits]), a certificate signing request for the given [hostname] and
       [additional_hostnames], and sends [server_ip] an nsupdate (DNS-TSIG with
-      [dns_key_name] and [dns_key]) with the csr as TLSA record, awaiting for a matching
+      [dns_key]) with the csr as TLSA record, awaiting for a matching
       certificate as TLSA record. Requires a service that interacts with let's
       encrypt to transform the CSR into a signed certificate. If something
       fails, an exception (via [Lwt.fail]) is raised. This is meant for


### PR DESCRIPTION
The reason is that the Dns.Dnskey.name_key_of_string return exactly that pair, and user code then looks nice :)