### PR TITLE
Fix Dns.Name_rr_map.pp

### DIFF
--- a/src/dns.ml
+++ b/src/dns.ml
@@ -3329,9 +3329,11 @@ module Name_rr_map = struct
     Domain_name.Map.equal (Rr_map.equal { f = Rr_map.equal_rr }) a b
 
   let pp ppf map =
-    List.iter (fun (name, rr_map) ->
-        Fmt.(list ~sep:(any "@.") string) ppf
-          (List.map (Rr_map.text_b name) (Rr_map.bindings rr_map)))
+    Fmt.(list ~sep:(any "@."))
+      (fun ppf (name, rr_map) ->
+         Fmt.(list ~sep:(any "@.") string) ppf
+           (List.map (Rr_map.text_b name) (Rr_map.bindings rr_map)))
+      ppf
       (Domain_name.Map.bindings map)
 
   let add name k v dmap =


### PR DESCRIPTION
The elements were not always separated when printing.

Before this patch I would see something like:

    ns3.google.com. 172800  AAAA    2001:4860:4802:36::ans4.google.com. 172800  A       216.239.38.10

where the more readable output is;

    ns3.google.com. 172800  AAAA    2001:4860:4802:36::a
    ns4.google.com. 172800  A       216.239.38.10