### PR TITLE
dnssec resolver: handling CD bit (checking disabled) properly

### DIFF
--- a/resolver/dns_resolver.ml
+++ b/resolver/dns_resolver.ml
@@ -29,7 +29,8 @@ type awaiting = {
   port : int;
   question : key;
   id : int;
-  cd : bool;
+  checking_disabled : bool;
+  dnssec_ok : bool;
 }
 
 let retry_interval = Duration.of_ms 500
@@ -77,7 +78,7 @@ let pick rng = function
   | [ x ] -> Some x
   | xs -> Some (List.nth xs (Randomconv.int ~bound:(List.length xs) rng))
 
-let build_query ?id ?(recursion_desired = false) ?(cd = false) t ts proto question retry zone edns ip =
+let build_query ?id ?(recursion_desired = false) ?(checking_disabled = false) ?(dnssec_ok = true) t ts proto question retry zone edns ip =
   let id = match id with Some id -> id | None -> Randomconv.int16 t.rng in
   let header =
     (* TODO not clear about this.. *)
@@ -89,7 +90,7 @@ let build_query ?id ?(recursion_desired = false) ?(cd = false) t ts proto questi
     in
     id, flags
   in
-  let el = { ts; retry; proto; zone; edns; ip; port = 53; question; id; cd } in
+  let el = { ts; retry; proto; zone; edns; ip; port = 53; question; id; checking_disabled; dnssec_ok } in
   let transit =
     if QM.mem question t.transit then
       Log.warn (fun m -> m "overwriting transit of %a" pp_key question) ;
@@ -109,7 +110,7 @@ let maybe_query ?recursion_desired t ts await retry ip name typ =
     (* TODO here we may want to use the _default protocol_ (and edns settings) instead of `Udp *)
     let payload_size = if t.dnssec then Some 1220 (* from RFC 4035 4.1 *) else None in
     let edns = Some (Edns.create ~dnssec_ok:t.dnssec ?payload_size ()) in
-    let t, packet = build_query ?recursion_desired ~cd:await.cd t ts `Udp k retry await.zone edns ip in
+    let t, packet = build_query ?recursion_desired ~checking_disabled:await.checking_disabled ~dnssec_ok:await.dnssec_ok t ts `Udp k retry await.zone edns ip in
     let t = { t with queried = QM.add k [await] t.queried } in
     Log.debug (fun m -> m "maybe_query: query %a %a" Ipaddr.pp ip pp_key k) ;
     Some (packet, ip), t
@@ -142,7 +143,8 @@ let handle_query ?(retry = 0) t ts awaiting =
                   pp_key awaiting.question Ipaddr.pp awaiting.ip awaiting.port);
     `Nothing, t
   end else
-    let r, cache = Dns_resolver_cache.handle_query t.cache ~dnssec:(t.dnssec && not awaiting.cd) ~rng:t.rng t.ip_protocol ts awaiting.question in
+    let dnssec = t.dnssec && not awaiting.checking_disabled && awaiting.dnssec_ok in
+    let r, cache = Dns_resolver_cache.handle_query t.cache ~dnssec ~rng:t.rng t.ip_protocol ts awaiting.question in
     let t = { t with cache } in
     match r with
     | `Query _ when awaiting.retry >= 30 ->
@@ -256,8 +258,9 @@ let resolve t ts proto sender sport req =
     if not (Packet.Flags.mem `Recursion_desired (snd req.Packet.header)) then
       Log.warn (fun m -> m "recursion not desired") ;
     (* ask the cache *)
-    let cd = Packet.Flags.mem `Checking_disabled (snd req.header) in
-    let awaiting = { ts; retry = 0; proto; zone = Domain_name.root ; edns = req.edns; ip = sender; port = sport; question = (fst req.question, q_type); id = fst req.header; cd } in
+    let checking_disabled = Packet.Flags.mem `Checking_disabled (snd req.header)
+    and dnssec_ok = match req.edns with None -> false | Some edns -> edns.Edns.dnssec_ok in
+    let awaiting = { ts; retry = 0; proto; zone = Domain_name.root ; edns = req.edns; ip = sender; port = sport; question = (fst req.question, q_type); id = fst req.header; checking_disabled; dnssec_ok } in
     begin match handle_query t ts awaiting with
       | `Answer pkt, t ->
         Log.debug (fun m -> m "answer %a" Packet.Question.pp req.question) ;
@@ -387,7 +390,10 @@ let handle_delegation t ts proto sender sport req (delegation, add_data) =
   Log.debug (fun m -> m "handling delegation %a (for %a)" Packet.Answer.pp delegation Packet.pp req) ;
   match req.Packet.data, Packet.Question.qtype req.question with
   | `Query, Some qtype ->
-    let dnssec = t.dnssec && not (Packet.Flags.mem `Checking_disabled (snd req.header)) in
+    let dnssec =
+      t.dnssec && not (Packet.Flags.mem `Checking_disabled (snd req.header)) &&
+      match req.edns with None -> false | Some edns -> edns.Edns.dnssec_ok
+    in
     let r, cache = Dns_resolver_cache.answer ~dnssec t.cache ts (fst req.question) qtype in
     let t = { t with cache } in
     begin match r with
@@ -421,7 +427,10 @@ let handle_delegation t ts proto sender sport req (delegation, add_data) =
             Log.debug (fun m -> m "found ip %a, maybe querying %a"
                            Ipaddr.pp ip pp_key (name, qtype)) ;
             (* TODO is Domain_name.root correct here? *)
-            let await = { ts; retry = 0; proto; zone = Domain_name.root; edns = req.edns; ip = sender; port = sport; question = (fst req.question, qtype); id = fst req.header; cd = Packet.Flags.mem `Checking_disabled (snd req.header) } in
+            let checking_disabled = Packet.Flags.mem `Checking_disabled (snd req.header)
+            and dnssec_ok = match req.edns with None -> false | Some edns -> edns.Edns.dnssec_ok
+            in
+            let await = { ts; retry = 0; proto; zone = Domain_name.root; edns = req.edns; ip = sender; port = sport; question = (fst req.question, qtype); id = fst req.header; checking_disabled; dnssec_ok } in
             begin match maybe_query ~recursion_desired:true t ts await 0 ip name qtype with
               | None, t ->
                 Log.warn (fun m -> m "maybe_query for %a at %a returned nothing"
@@ -530,10 +539,11 @@ let query_root t now proto =
   let question = Domain_name.root, `K (Rr_map.K Ns)
   and id = Randomconv.int16 t.rng
   and edns = Some (Edns.create ())
-  and cd = false
+  and checking_disabled = false
+  and dnssec_ok = true
   in
   let el =
-    { ts = now; retry = 0; proto; zone = Domain_name.root; edns; ip; port = 53; question; id; cd }
+    { ts = now; retry = 0; proto; zone = Domain_name.root; edns; ip; port = 53; question; id; checking_disabled; dnssec_ok }
   in
   let t = { t with transit = QM.add question el t.transit } in
   let packet = Packet.create ?edns (id, Packet.Flags.empty) question `Query in

--- a/resolver/dns_resolver_cache.mli
+++ b/resolver/dns_resolver_cache.mli
@@ -8,7 +8,7 @@ val follow_cname : Dns_cache.t -> int64 -> 'a Rr_map.key -> name:[ `raw ] Domain
   [ `Out of Rcode.t * bool * Name_rr_map.t * Name_rr_map.t
   | `Query of [ `raw ] Domain_name.t ] * Dns_cache.t
 
-val answer : Dns_cache.t -> int64 -> [ `raw ] Domain_name.t -> Packet.Question.qtype ->
+val answer : dnssec:bool -> Dns_cache.t -> int64 -> [ `raw ] Domain_name.t -> Packet.Question.qtype ->
   [ `Query of [ `raw ] Domain_name.t
   | `Packet of Packet.Flags.t * Packet.reply ] * Dns_cache.t
 


### PR DESCRIPTION
/cc @reynir -- covered in various RFCs, but the bottom line is:
- if the client sent CD bit, we should reply also with unsigned data
- we thus always insert data into our cache (with the appropriate rank, to have the is_signed check being appropriate)
- when we reply, and there was demand for dnssec, we reply with server failure in the case CD is not set and thus dnssec was requested

we also check for the edns dnssec_ok bit whether we should query with dnssec or not.

bugs may still be if we have a client asking for no dnssec, and thereafter a client asking for dnssec -- and the response is not properly signed

the other way around, there may as well be bugs.

I'm now also unsure whether the behaviour is the intended one, will need to re-read the RFCs.