### PR TITLE
DNS: support for Extended DNS error (RFC 8914)

### DIFF
--- a/app/odnssec.ml
+++ b/app/odnssec.ml
@@ -57,6 +57,11 @@ let jump () hostname typ ns =
                          | Error `Msg msg ->
                            Logs.warn (fun m -> m "couldn't validate DS (for %a): %s"
                                          Domain_name.pp requested_domain msg);
+                           acc
+                         | Error `Extended e ->
+                           Logs.warn (fun m -> m "couldn't validate DS (for %a): %a"
+                                         Domain_name.pp requested_domain
+                                         Extended_error.pp e);
                            acc)
                        ds_set Rr_map.Dnskey_set.empty
                    in

--- a/dnssec/dnssec.ml
+++ b/dnssec/dnssec.ml
@@ -84,10 +84,11 @@ let digest algorithm owner dnskey =
   | Ds.SHA256 -> digest Digestif.SHA256
   | Ds.SHA384 -> digest Digestif.SHA384
   | dt ->
-    Error (`Msg (Fmt.str "Unsupported hash algorithm %a"
-                   Ds.pp_digest_type dt))
+    Error (`Extended (`Unsupported_Ds_digest,
+                      Some (Fmt.str "DS %a: unkown digest type: %a"
+                              Domain_name.pp owner Ds.pp_digest_type dt)))
 
-let dnskey_to_pk { Dnskey.algorithm ; key ; _ } =
+let dnskey_to_pk req_dom { Dnskey.algorithm ; key ; _ } =
   let map_ec_err r =
     Result.map_error (fun e -> `Msg (Fmt.to_to_string Mirage_crypto_ec.pp_error e)) r
   in
@@ -117,11 +118,13 @@ let dnskey_to_pk { Dnskey.algorithm ; key ; _ } =
     let* pub = map_ec_err (Mirage_crypto_ec.Ed25519.pub_of_octets key) in
     Ok (`ED25519 pub)
   | MD5 | SHA1 | SHA224 | SHA256 | SHA384 | SHA512 | Unknown _ ->
-    Error (`Msg (Fmt.str "unsupported key algorithm %a" Dnskey.pp_algorithm algorithm))
+    Error (`Extended (`Unsupported_Dnskey_algorithm,
+                      Some (Fmt.str "%a DNSKEY unsupported algorithm: %a"
+                              Domain_name.pp req_dom Dnskey.pp_algorithm algorithm)))
 
 let verify : type a . Ptime.t -> pub -> [`raw] Domain_name.t -> Rrsig.t ->
   a Rr_map.key -> a ->
-  ([`raw] Domain_name.t * [`raw] Domain_name.t, [ `Msg of string ]) result =
+  ([`raw] Domain_name.t * [`raw] Domain_name.t, [> `Msg of string | `Extended of Extended_error.t ]) result =
   fun now key name rrsig t v ->
   (* from RFC 4034 section 3.1.8.1 *)
   Log.debug (fun m -> m "verifying for %a (with %a / %a)" Domain_name.pp name
@@ -136,8 +139,12 @@ let verify : type a . Ptime.t -> pub -> [`raw] Domain_name.t -> Rrsig.t ->
     | Dnskey.P256_SHA256 -> Ok `SHA256
     | Dnskey.P384_SHA384 -> Ok `SHA384
     | Dnskey.ED25519 -> Ok `SHA512
-    | a -> Error (`Msg (Fmt.str "unsupported signature algorithm %a"
-                          Dnskey.pp_algorithm a)) in
+    | a ->
+      let msg =
+        Fmt.str "unsupported signature algorithm %a" Dnskey.pp_algorithm a
+      in
+      Error (`Extended (`Other, Some msg))
+  in
   let digest data =
     match rrsig.Rrsig.algorithm with
     | Dnskey.RSA_SHA1 -> Digestif.SHA1.(digest_string data |> to_raw_string)
@@ -151,11 +158,11 @@ let verify : type a . Ptime.t -> pub -> [`raw] Domain_name.t -> Rrsig.t ->
   in
   let* () =
     guard (Ptime.is_later ~than:now rrsig.Rrsig.signature_expiration)
-      (`Msg "signature timestamp expired")
+      (`Extended (`Signature_expired, None))
   in
   let* () =
     guard (Ptime.is_later ~than:rrsig.Rrsig.signature_inception now)
-      (`Msg "signature not yet incepted")
+      (`Extended (`Signature_not_yet_valid, None))
   in
   let* (used_name, data) = Rr_map.prep_for_sig name rrsig t v in
   let hashed () = digest data in
@@ -235,8 +242,8 @@ let validate_rrsig_keys now dnskeys rrsigs requested_domain t v =
   in
   Log.debug (fun m -> m "found %d key-rrsig pairs" (List.length keys_rrsigs));
   let verify_signature (key, rrsig) =
-    let* pkey = dnskey_to_pk key in
-    open_err (verify now pkey requested_domain rrsig t v)
+    let* pkey = dnskey_to_pk requested_domain key in
+    verify now pkey requested_domain rrsig t v
   in
   match List.partition Result.is_ok (List.map verify_signature keys_rrsigs) with
   | r :: _, _ -> r
@@ -817,7 +824,13 @@ let check_signatures now dnskeys map =
             | Error `Msg msg ->
               Log.warn (fun m -> m "RRSIG verification for %a %a failed: %s"
                            Domain_name.pp name Rr_map.pp_b b msg);
-              acc) rr_map (signer_name, (Rr_map.empty, KM.empty))
+              acc
+            | Error `Extended e ->
+              Log.warn (fun m -> m "RRSIG verification for %a %a failed: %a"
+                           Domain_name.pp name Rr_map.pp_b b
+                           Extended_error.pp e);
+              acc)
+          rr_map (signer_name, (Rr_map.empty, KM.empty))
       in
       signer_name,
       if Rr_map.is_empty (fst rrs) then

--- a/dnssec/dnssec.ml
+++ b/dnssec/dnssec.ml
@@ -15,11 +15,6 @@ let pp_km_name_rr_map ppf rrs =
 
 let guard a e = if a then Ok () else Error e
 
-let open_err : ('a, [ `Msg of string ]) result ->
-  ('a, [> `Msg of string ]) result = function
-  | Ok _ as a -> a
-  | Error (`Msg _) as b -> b
-
 let root_ds =
   (* <KeyDigest id="Klajeyz" validFrom="2017-02-02T00:00:00+00:00">
   <KeyTag>20326</KeyTag>

--- a/resolver/dns_resolver.ml
+++ b/resolver/dns_resolver.ml
@@ -325,6 +325,11 @@ let handle_reply t now ts proto sender packet reply =
                             | Error `Msg msg ->
                               Log.debug (fun m -> m "couldn't validate DS (for %a): %s"
                                             Domain_name.pp zone msg);
+                              acc
+                            | Error `Extended e ->
+                              Log.debug (fun m -> m "couldn't validate DS (for %a): %a"
+                                            Domain_name.pp zone
+                                            Extended_error.pp e);
                               acc)
                           ds_set Rr_map.Dnskey_set.empty)
                       keys

--- a/src/dns.ml
+++ b/src/dns.ml
@@ -2896,6 +2896,130 @@ module Tsig = struct
     | Dnskey.Unknown x -> Error (`Msg ("Unknown DNSKEY algorithm " ^ string_of_int x))
 end
 
+module Extended_error = struct
+  type t =
+    [ `Other | `Unsupported_Dnskey_algorithm | `Unsupported_Ds_digest
+    | `Stale_answer | `Forged_answer | `Dnssec_indeterminate
+    | `Dnssec_bogus | `Signature_expired | `Signature_not_yet_valid
+    | `Dnskey_missing | `Rrsigs_missing | `No_zone_key_bit_set
+    | `Nsec_missing | `Cached_error | `Not_ready | `Blocked
+    | `Censored | `Filtered | `Prohibited | `Stale_Nxdomain_answer
+    | `Not_authoritative | `Not_supported | `No_reachable_authority
+    | `Network_error | `Invalid_data | `Unknown of int ] *
+    string option
+
+  let to_int = function
+    | `Other -> 0
+    | `Unsupported_Dnskey_algorithm -> 1
+    | `Unsupported_Ds_digest -> 2
+    | `Stale_answer -> 3
+    | `Forged_answer -> 4
+    | `Dnssec_indeterminate -> 5
+    | `Dnssec_bogus -> 6
+    | `Signature_expired -> 7
+    | `Signature_not_yet_valid -> 8
+    | `Dnskey_missing -> 9
+    | `Rrsigs_missing -> 10
+    | `No_zone_key_bit_set -> 11
+    | `Nsec_missing -> 12
+    | `Cached_error -> 13
+    | `Not_ready -> 14
+    | `Blocked -> 15
+    | `Censored -> 16
+    | `Filtered -> 17
+    | `Prohibited -> 18
+    | `Stale_Nxdomain_answer -> 19
+    | `Not_authoritative -> 20
+    | `Not_supported -> 21
+    | `No_reachable_authority -> 22
+    | `Network_error -> 23
+    | `Invalid_data -> 24
+    | `Unknown i -> i
+
+  let of_int = function
+    | 0 -> `Other
+    | 1 -> `Unsupported_Dnskey_algorithm
+    | 2 -> `Unsupported_Ds_digest
+    | 3 -> `Stale_answer
+    | 4 -> `Forged_answer
+    | 5 -> `Dnssec_indeterminate
+    | 6 -> `Dnssec_bogus
+    | 7 -> `Signature_expired
+    | 8 -> `Signature_not_yet_valid
+    | 9 -> `Dnskey_missing
+    | 10 -> `Rrsigs_missing
+    | 11 -> `No_zone_key_bit_set
+    | 12 -> `Nsec_missing
+    | 13 -> `Cached_error
+    | 14 -> `Not_ready
+    | 15 -> `Blocked
+    | 16 -> `Censored
+    | 17 -> `Filtered
+    | 18 -> `Prohibited
+    | 19 -> `Stale_Nxdomain_answer
+    | 20 -> `Not_authoritative
+    | 21 -> `Not_supported
+    | 22 -> `No_reachable_authority
+    | 23 -> `Network_error
+    | 24 -> `Invalid_data
+    | i -> `Unknown i
+
+  let pp ppf (t, data) =
+    let prefix =
+      match t with
+      | `Other -> "other"
+      | `Unsupported_Dnskey_algorithm -> "unsupported DNSKEY algorithm"
+      | `Unsupported_Ds_digest -> "unsupported DS digest"
+      | `Stale_answer -> "stale answer"
+      | `Forged_answer -> "forged answer"
+      | `Dnssec_indeterminate -> "DNSSEC indeterminate"
+      | `Dnssec_bogus -> "DNSSEC bogus"
+      | `Signature_expired -> "signature expired"
+      | `Signature_not_yet_valid -> "signature not yet valid"
+      | `Dnskey_missing -> "DNSKEY missing"
+      | `Rrsigs_missing -> "RRSIGs missing"
+      | `No_zone_key_bit_set -> "no zone key bit set"
+      | `Nsec_missing -> "NSEC missing"
+      | `Cached_error -> "cached error"
+      | `Not_ready -> "not ready"
+      | `Blocked -> "blocked"
+      | `Censored -> "censored"
+      | `Filtered -> "filtered"
+      | `Prohibited -> "prohibited"
+      | `Stale_Nxdomain_answer -> "stale NXDOMAIN answer"
+      | `Not_authoritative -> "not authoritative"
+      | `Not_supported -> "not supported"
+      | `No_reachable_authority -> "no reachable authority"
+      | `Network_error -> "network error"
+      | `Invalid_data -> "invalid data"
+      | `Unknown t -> "unknown (" ^ string_of_int t ^ ")"
+    in
+    Fmt.pf ppf "%s%s" prefix (match data with None -> "" | Some s -> " " ^ s)
+
+  let compare (t, d) (t', d') =
+    andThen (Int.compare (to_int t) (to_int t'))
+      (match d, d' with
+       | None, None -> 0
+       | None, Some _ -> -1
+       | Some _, None -> 1
+       | Some s, Some s' -> String.compare s s')
+
+  let encode (t, v) =
+    let buf = Bytes.create 2 in
+    Bytes.set_uint16_be buf 0 (to_int t);
+    Bytes.unsafe_to_string buf ^ Option.value ~default:"" v
+
+  let decode buf =
+    let t = of_int (String.get_uint16_be buf 0) in
+    let v =
+      if String.length buf > 2 then
+        Some (String.sub buf 2 (String.length buf - 2))
+      else
+        None
+    in
+    t, v
+end
+
 module Edns = struct
 
   type extension =
@@ -2903,6 +3027,7 @@ module Edns = struct
     | Cookie of string
     | Tcp_keepalive of int option
     | Padding of int
+    | Extended_error of Extended_error.t
     | Extension of int * string
 
   let pp_extension ppf = function
@@ -2910,6 +3035,7 @@ module Edns = struct
     | Cookie cs -> Fmt.pf ppf "cookie %a" (Ohex.pp_hexdump ()) cs
     | Tcp_keepalive i -> Fmt.pf ppf "keepalive %a" Fmt.(option ~none:(any "none") int) i
     | Padding i -> Fmt.pf ppf "padding %d" i
+    | Extended_error e -> Extended_error.pp ppf e
     | Extension (t, v) -> Fmt.pf ppf "unknown option %d: %a" t (Ohex.pp_hexdump ()) v
 
   let compare_extension a b = match a, b with
@@ -2927,6 +3053,8 @@ module Edns = struct
     | Tcp_keepalive _, _ -> 1 | _, Tcp_keepalive _ -> -1
     | Padding a, Padding b -> Int.compare a b
     | Padding _, _ -> 1 | _, Padding _ -> -1
+    | Extended_error e, Extended_error e' -> Extended_error.compare e e'
+    | Extended_error _, _ -> 1 | _, Extended_error _ -> -1
     | Extension (t, v), Extension (t', v') ->
       andThen (Int.compare t t') (String.compare v v')
 
@@ -2936,6 +3064,7 @@ module Edns = struct
     | Cookie _ -> 10
     | Tcp_keepalive _ -> 11
     | Padding _ -> 12
+    | Extended_error _ -> 15
     | Extension (tag, _) -> tag
 
   let int_to_extension = function
@@ -2943,6 +3072,7 @@ module Edns = struct
     | 10 -> Some `cookie
     | 11 -> Some `tcp_keepalive
     | 12 -> Some `padding
+    | 15 -> Some `extended_error
     | _ -> None
 
   let extension_payload = function
@@ -2956,6 +3086,7 @@ module Edns = struct
          Bytes.set_uint16_be buf 0 i ;
          Bytes.unsafe_to_string buf)
     | Padding i -> String.make i '\x00'
+    | Extended_error e -> Extended_error.encode e
     | Extension (_, v) -> v
 
   let encode_extension t buf off =
@@ -2985,6 +3116,7 @@ module Edns = struct
       in
       Ok (Tcp_keepalive i, len)
     | Some `padding -> Ok (Padding tl, len)
+    | Some `extended_error -> Ok (Extended_error (Extended_error.decode v), len)
     | None -> Ok (Extension (code, v), len)
 
   type t = {
@@ -2999,7 +3131,7 @@ module Edns = struct
 
   let min_payload_size = 512 (* from RFC 6891 Section 6.2.3 *)
 
-  let create ?(extended_rcode = 0) ?(version = 0) ?(dnssec_ok = false)
+  let create ?extended_error ?(extended_rcode = 0) ?(version = 0) ?(dnssec_ok = false)
       ?(payload_size = min_payload_size) ?(extensions = []) () =
     let payload_size =
       if payload_size < min_payload_size then begin
@@ -3008,6 +3140,10 @@ module Edns = struct
         min_payload_size
       end else
         payload_size
+    in
+    let extensions = match extended_error with
+      | None -> extensions
+      | Some e -> Extended_error e :: extensions
     in
     { extended_rcode ; version ; dnssec_ok ; payload_size ; extensions }
 

--- a/src/dns.mli
+++ b/src/dns.mli
@@ -805,6 +805,24 @@ module Tsig : sig
      matches [ts]. *)
 end
 
+(** Extended DNS errors
+
+    Standardized in RFC 8914, this is a payload for Edns with a additional
+    information about the cause of a DNS error.
+*)
+module Extended_error : sig
+  type t =
+    [ `Other | `Unsupported_Dnskey_algorithm | `Unsupported_Ds_digest
+    | `Stale_answer | `Forged_answer | `Dnssec_indeterminate
+    | `Dnssec_bogus | `Signature_expired | `Signature_not_yet_valid
+    | `Dnskey_missing | `Rrsigs_missing | `No_zone_key_bit_set
+    | `Nsec_missing | `Cached_error | `Not_ready | `Blocked
+    | `Censored | `Filtered | `Prohibited | `Stale_Nxdomain_answer
+    | `Not_authoritative | `Not_supported | `No_reachable_authority
+    | `Network_error | `Invalid_data | `Unknown of int ] *
+    string option
+end
+
 (** Extensions to DNS
 
     An extension record (EDNS) is extendable, includes a version number, payload
@@ -817,6 +835,7 @@ module Edns : sig
     | Cookie of string
     | Tcp_keepalive of int option
     | Padding of int
+    | Extended_error of Extended_error.t
     | Extension of int * string
   (** The type of supported extensions. *)
 
@@ -829,9 +848,10 @@ module Edns : sig
   }
   (** The type of an EDNS record. *)
 
-  val create : ?extended_rcode:int -> ?version:int -> ?dnssec_ok:bool ->
-    ?payload_size:int -> ?extensions:extension list -> unit -> t
-  (** [create ~extended_rcode ~version ~dnssec_ok ~payload_size ~extensions ()]
+  val create : ?extended_error:Extended_error.t -> ?extended_rcode:int ->
+    ?version:int -> ?dnssec_ok:bool -> ?payload_size:int ->
+    ?extensions:extension list -> unit -> t
+  (** [create ~extended_erro ~extended_rcode ~version ~dnssec_ok ~payload_size ~extensions ()]
      constructs an EDNS record with the optionally provided data. The
      [extended_rcode] defaults to 0, [version] defaults to 0, [dnssec_ok] to
      false, [payload_size] to the minimum payload size (512 byte), [extensions]

--- a/src/dns.mli
+++ b/src/dns.mli
@@ -387,7 +387,7 @@ module Dnskey : sig
   (** [int_to_algorithm i] decodes [i] to an [algorithm].
 
       @raise Invalid_argument if [i] does not fit in one octet.
- *)
+  *)
 
   val algorithm_to_int : algorithm -> int
   (** [algorithm_to_int a] encodes [a] to an integer. *)
@@ -821,6 +821,9 @@ module Extended_error : sig
     | `Not_authoritative | `Not_supported | `No_reachable_authority
     | `Network_error | `Invalid_data | `Unknown of int ] *
     string option
+
+  val pp : t Fmt.t
+  (** [pp ppf e] pretty-prints the error. *)
 end
 
 (** Extensions to DNS
@@ -1056,7 +1059,7 @@ module Rr_map : sig
   (** [with_ttl k v ttl] updates [ttl] in [v]. *)
 
   val prep_for_sig : [`raw] Domain_name.t -> Rrsig.t -> 'a key -> 'a ->
-    ([`raw] Domain_name.t * string, [ `Msg of string ]) result
+    ([`raw] Domain_name.t * string, [> `Msg of string ]) result
 
   val canonical_encoded_name : [`raw] Domain_name.t -> string
 

--- a/test/test_dnssec.ml
+++ b/test/test_dnssec.ml
@@ -125,7 +125,7 @@ let test_root () =
                             (String.equal ds_root.Ds.digest dgst))
             end;
             begin
-              match Dnssec.dnskey_to_pk used_dnskey with
+              match Dnssec.dnskey_to_pk Domain_name.root used_dnskey with
               | Ok `RSA k ->
                 Alcotest.(check bool (__LOC__ ^ " key successfully extracted") true
                             ((Z.equal key.Mirage_crypto_pk.Rsa.e k.Mirage_crypto_pk.Rsa.e) &&
@@ -137,6 +137,9 @@ let test_root () =
               | Ok _used_name -> ()
               | Error (`Msg m) ->
                 Alcotest.failf "%s signature verification failed %s" __LOC__ m
+              | Error (`Extended e) ->
+                Alcotest.failf "%s signature verification failed %s" __LOC__
+                  (Fmt.to_to_string Extended_error.pp e)
             end
           | _ -> Alcotest.fail (__LOC__ ^ " expected dnskey and rrsig")
       end


### PR DESCRIPTION
~~it's not yet used anywhere, so a bit boring... ;)~~

but we can use this now e.g. for dnssec validation (and better errors) \o/

it is now used in dnssec :)