### PR TITLE
Fix the dns-cache metrics: we count the hits and misses etc.

### DIFF
--- a/cache/dns_cache.ml
+++ b/cache/dns_cache.ml
@@ -122,7 +122,7 @@ module LRU = Lru.F.Make(Key)(Entry)
 
 type t = LRU.t
 
-let metrics cache =
+let metrics =
   let f = function
     | `Lookup -> "lookups"
     | `Hit -> "hits"
@@ -130,13 +130,8 @@ let metrics cache =
     | `Drop -> "drops"
     | `Insert -> "insertions"
   in
-  let static () = [
-    Metrics.uint "size" (LRU.size cache);
-    Metrics.uint "weight" (LRU.weight cache);
-    Metrics.uint "capacity" (LRU.capacity cache)
-  ] in
-  let metrics = Dns.counter_metrics ~f ~static "dns-cache" in
-  (fun x -> Metrics.add metrics (fun x -> x) (fun d -> d x))
+  let src = Dns.counter_metrics ~f "dns-cache" in
+  (fun r -> Metrics.add src (fun x -> x) (fun d -> d r))
 
 let empty = LRU.empty
 
@@ -201,13 +196,13 @@ let update_ttl typ entry ~created ~now =
   if updated_ttl < 0l then Error `Cache_drop else Ok (with_ttl typ updated_ttl entry)
 
 let get cache ts name query_type =
-  metrics cache `Lookup;
+  metrics `Lookup;
   match snd (find cache name query_type) with
-  | Error e -> metrics cache `Miss; cache, Error e
+  | Error e -> metrics `Miss; cache, Error e
   | Ok ((created, rank), entry) ->
     match update_ttl query_type entry ~created ~now:ts with
-    | Ok entry' -> metrics cache `Hit; LRU.promote name cache, Ok (entry', rank)
-    | Error e -> metrics cache `Drop; cache, Error e
+    | Ok entry' -> metrics `Hit; LRU.promote name cache, Ok (entry', rank)
+    | Error e -> metrics `Drop; cache, Error e
 
 let find_any cache name =
   match LRU.find name cache with
@@ -216,9 +211,9 @@ let find_any cache name =
   | Some Rr_map rrs -> Ok (`Entries rrs)
 
 let get_any cache ts name =
-  metrics cache `Lookup;
+  metrics `Lookup;
   match find_any cache name with
-  | Error e -> metrics cache `Miss; cache, Error e
+  | Error e -> metrics `Miss; cache, Error e
   | Ok r ->
     let ttl created curr =
       let ttl = compute_updated_ttl ~created ~now:ts curr in
@@ -228,9 +223,9 @@ let get_any cache ts name =
     match r with
     | `No_domain ((created, rank), name, soa) ->
       begin match ttl created soa.Soa.minimum with
-        | Error _ as e -> metrics cache `Drop; e
+        | Error _ as e -> metrics `Drop; e
         | Ok minimum ->
-          metrics cache `Hit;
+          metrics `Hit;
           Ok (`No_domain (name, { soa with Soa.minimum }), rank)
       end
     | `Entries rrs ->
@@ -247,20 +242,20 @@ let get_any cache ts name =
             | _ -> acc, r) rrs (Rr_map.empty, Additional)
       in
       match Rr_map.is_empty rrs with
-      | true -> metrics cache `Drop; Error `Cache_drop
-      | false -> metrics cache `Hit; Ok (`Entries rrs, r)
+      | true -> metrics `Drop; Error `Cache_drop
+      | false -> metrics `Hit; Ok (`Entries rrs, r)
 
 let get_or_cname : type a . t -> int64 -> [`raw] Domain_name.t -> a Rr_map.key ->
   t * ([ a entry | `Alias of int32 * [`raw] Domain_name.t] * rank,
        [ `Cache_drop | `Cache_miss ]) result =
   fun cache ts name query_type ->
-  metrics cache `Lookup;
+  metrics `Lookup;
   let map_result : _ -> t * ([ a entry | `Alias of int32 * [`raw] Domain_name.t] * rank, [ `Cache_drop | `Cache_miss ]) result = function
-    | Error e -> metrics cache `Miss; cache, Error e
+    | Error e -> metrics `Miss; cache, Error e
     | Ok ((created, rank), entry) ->
       match update_ttl query_type entry ~created ~now:ts with
-      | Ok entry' -> metrics cache `Hit; LRU.promote name cache, Ok ((entry', rank) :> [ _ entry | `Alias of int32 * [`raw] Domain_name.t ] * rank)
-      | Error e -> metrics cache `Drop; cache, Error e
+      | Ok entry' -> metrics `Hit; LRU.promote name cache, Ok ((entry', rank) :> [ _ entry | `Alias of int32 * [`raw] Domain_name.t ] * rank)
+      | Error e -> metrics `Drop; cache, Error e
   in
   match find cache name query_type with
   | Some map, r ->
@@ -270,7 +265,7 @@ let get_or_cname : type a . t -> int64 -> [`raw] Domain_name.t -> a Rr_map.key -
         if ttl < 0l then
           map_result r
         else begin
-          metrics cache `Hit;
+          metrics `Hit;
           LRU.promote name cache, Ok (`Alias (ttl, name), rank)
         end
       | _ -> map_result r
@@ -278,7 +273,7 @@ let get_or_cname : type a . t -> int64 -> [`raw] Domain_name.t -> a Rr_map.key -
   | _, e -> map_result e
 
 let get_nsec3 cache ts name =
-  metrics cache `Lookup;
+  metrics `Lookup;
   let zone_labels = Domain_name.count_labels name in
   let nsec3_rrs =
     LRU.fold (fun ename entry acc ->
@@ -305,10 +300,10 @@ let get_nsec3 cache ts name =
   in
   match nsec3_rrs with
   | [] ->
-    metrics cache `Miss;
+    metrics `Miss;
     cache, Error `Cache_miss
   | xs ->
-    metrics cache `Hit;
+    metrics `Hit;
     List.fold_right LRU.promote (List.map (fun (a, _, _, _) -> a) xs) cache,
     Ok xs
 
@@ -352,13 +347,13 @@ let set cache ts name query_type rank entry  =
   | map, Error _ ->
     Log.debug (fun m -> m "set: %a nothing found, adding: %a"
                    pp_query (name, `K (K query_type)) (pp_entry query_type) entry');
-    metrics cache `Insert; cache' map
+    metrics `Insert; cache' map
   | map, Ok ((created, rank'), entry) ->
     Log.debug (fun m -> m "set: %a found rank %a insert rank %a: %d"
                    pp_query (name, `K (K query_type)) pp_rank rank' pp_rank rank (compare_rank rank' rank));
     match update_ttl query_type entry ~created ~now:ts, compare_rank rank' rank with
     | Ok _, 1 -> cache
-    | _ -> metrics cache `Insert; cache' map
+    | _ -> metrics `Insert; cache' map
 
 let remove cache name =
   LRU.remove name cache

--- a/src/dns.ml
+++ b/src/dns.ml
@@ -5919,10 +5919,9 @@ let create ~f =
   (fun () ->
      Hashtbl.fold (fun key value acc -> Metrics.uint key value :: acc) data [])
 
-let counter_metrics ~f ?static name =
+let counter_metrics ~f name =
   let open Metrics in
   let doc = "Counter metrics" in
   let incr, get = create ~f in
-  let static = Option.value ~default:(fun () -> []) static in
-  let data thing = incr thing; Data.v (static () @ get ()) in
+  let data thing = incr thing; Data.v (get ()) in
   Src.v ~doc ~tags:Metrics.Tags.[] ~data name

--- a/src/dns.mli
+++ b/src/dns.mli
@@ -1460,5 +1460,4 @@ end
 
 (**/**)
 val counter_metrics : f:('a -> string) ->
-  ?static:(unit -> Metrics.field list) ->
   string -> (Metrics.field list, 'a -> Metrics.Data.t) Metrics.src


### PR DESCRIPTION
Previous code was from a time where the cache was different, and didn't work - it allocated lots of metrics sources.

For now, we do not collect the capacity etc. of the LRU - we can do that in another iteration.