### PR TITLE
dns-resolver: allow updates to the primary

### DIFF
--- a/mirage/resolver/dns_resolver_mirage.mli
+++ b/mirage/resolver/dns_resolver_mirage.mli
@@ -15,4 +15,12 @@ module Make (S : Tcpip.Stack.V4V6) : sig
   val resolve_external : t -> Ipaddr.t * int -> string -> (int32 * string) Lwt.t
   (** [resolve_external t (ip, port) data] resolves for [(ip, port)] the query
       [data] and returns a pair of the minimum TTL and a response. *)
+
+  val primary_data : t -> Dns_trie.t
+  (** [primary_data t] is the DNS trie of the primary for the resolver [t]. *)
+
+  val update_primary_data : t -> Dns_trie.t -> unit Lwt.t
+  (** [update_primary_data t data] updates the primary for the resolver [t]
+      with the DNS trie [data]. The Lwt promise resolves once all secondaries
+      are notified (if any). *)
 end

--- a/resolver/dns_resolver.ml
+++ b/resolver/dns_resolver.ml
@@ -652,3 +652,9 @@ let timer t ts =
         ({ t with queried }, out_as @ out_a, out_q)
       end)
     rem (t, [], [])
+
+let primary_data t = Dns_server.Primary.data t.primary
+
+let with_primary_data t now ts data =
+  let primary, outs = Dns_server.Primary.with_data t.primary now ts data in
+  { t with primary }, outs

--- a/resolver/dns_resolver.mli
+++ b/resolver/dns_resolver.mli
@@ -37,3 +37,11 @@ val timer : t -> int64 ->
     * (Dns.proto * Ipaddr.t * string) list
 (** [timer t now] potentially retransmits DNS requests and/or sends NXDomain
     answers. *)
+
+val primary_data : t -> Dns_trie.t
+(** [primary_data t] is the DNS trie of the primary. *)
+
+val with_primary_data : t -> Ptime.t -> int64 -> Dns_trie.t -> t * (Ipaddr.t * string list) list
+(** [with_primary_data t now ts data] is a pair [(t', outs)] where [t'] is [t]
+    updated with the [data] DNS trie, and [outs] is the data to send out (if
+    any). *)


### PR DESCRIPTION
This allows us to dynamically update the DNS primary in Dns_mirage_resolver. 

**TODO:**

- [ ] actually send out `notify`s to all secondaries. I think it's unlikely that we will run this with secondaries so I have not bothered implementing that for now.