### PR TITLE
resolver: Use Blocked EDE over Filtered

### DIFF
--- a/resolver/dns_resolver.ml
+++ b/resolver/dns_resolver.ml
@@ -301,10 +301,9 @@ let handle_primary t now ts proto sender sport packet _request buf =
             let edns =
               match reply.edns with
               | None ->
-                (* reynir: other candidates: `Blocked, `Censored, `Prohibited *)
-                Some (Edns.create ~extended_error:(`Filtered, None) ())
+                Some (Edns.create ~extended_error:(`Blocked, None) ())
               | Some ({ Edns.extensions = []; extended_rcode; version; dnssec_ok; payload_size }) ->
-                Some (Edns.create ~extended_error:(`Filtered, None) ~extended_rcode ~version ~dnssec_ok ~payload_size ())
+                Some (Edns.create ~extended_error:(`Blocked, None) ~extended_rcode ~version ~dnssec_ok ~payload_size ())
               | Some edns ->
                 Log.warn (fun m -> m "don't know how to extend edns to add extended error; not doing anything:@ %a" Edns.pp edns);
                 Some edns


### PR DESCRIPTION
Initially, Filtered was chosen because it communicated it was filtered due to the client requesting that. That sort of made sense in my head because I was running my own resolver. However, there's no guarantee of that - it may be a guest on my network etc etc.

Furthermore, pi-hole uses Blocked and the description of Blocked is more neutral.

See also previous discussion here: https://github.com/mirage/ocaml-dns/pull/380#issuecomment-3000649566