### PR TITLE
Dns_stub: provide an interface, which is fairly similar to Dns_resolver_mirage

### DIFF
--- a/dns-certify.opam
+++ b/dns-certify.opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 license: "BSD-2-Clause"
 
 depends: [
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.8.0"}
   "ocaml" {>= "4.13.0"}
   "dns" {= version}
   "dns-tsig" {= version}

--- a/dns-cli.opam
+++ b/dns-cli.opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 license: "BSD-2-Clause"
 
 depends: [
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.8.0"}
   "ocaml" {>= "4.13.0"}
   "dns" {= version}
   "dnssec" {= version}

--- a/dns-client-lwt.opam
+++ b/dns-client-lwt.opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "dune" {>="2.7.0"}
+  "dune" {>="2.8.0"}
   "ocaml" {>= "4.13.0"}
   "dns-client" {= version}
   "dns" {= version}

--- a/dns-client-miou-unix.opam
+++ b/dns-client-miou-unix.opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "dune" {>="2.7.0"}
+  "dune" {>="2.8.0"}
   "ocaml" {>= "5.0.0"}
   "dns-client" {= version}
   "domain-name" {>= "0.4.0"}

--- a/dns-client-mirage.opam
+++ b/dns-client-mirage.opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "dune" {>="2.7.0"}
+  "dune" {>="2.8.0"}
   "ocaml" {>= "4.13.0"}
   "dns-client" {= version}
   "domain-name" {>= "0.4.0"}

--- a/dns-client.opam
+++ b/dns-client.opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "dune" {>="2.7.0"}
+  "dune" {>="2.8.0"}
   "ocaml" {>= "4.13.0"}
   "dns" {= version}
   "randomconv" {>= "0.2.0"}

--- a/dns-mirage.opam
+++ b/dns-mirage.opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 license: "BSD-2-Clause"
 
 depends: [
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.8.0"}
   "ocaml" {>= "4.13.0"}
   "cstruct" {>= "6.0.0"}
   "dns" {= version}

--- a/dns-resolver.opam
+++ b/dns-resolver.opam
@@ -29,6 +29,7 @@ depends: [
   "mirage-crypto-rng" {>= "1.0.0"}
   "ca-certs-nss" {>= "3.113.1"}
   "ipaddr" {>= "5.6.1"}
+  "metrics" {>= "0.5.0"}
 ]
 
 build: [

--- a/dns-resolver.opam
+++ b/dns-resolver.opam
@@ -28,6 +28,7 @@ depends: [
   "tls-mirage" {>= "1.0.0"}
   "mirage-crypto-rng" {>= "1.0.0"}
   "ca-certs-nss" {>= "3.113.1"}
+  "ipaddr" {>= "5.6.1"}
 ]
 
 build: [

--- a/dns-resolver.opam
+++ b/dns-resolver.opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 license: "BSD-2-Clause"
 
 depends: [
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.8.0"}
   "ocaml" {>= "4.13.0"}
   "dns" {= version}
   "dns-server" {= version}

--- a/dns-server.opam
+++ b/dns-server.opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 license: "BSD-2-Clause"
 
 depends: [
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.8.0"}
   "ocaml" {>= "4.13.0"}
   "cstruct" {>= "6.0.0"}
   "dns" {= version}

--- a/dns-stub.opam
+++ b/dns-stub.opam
@@ -24,6 +24,7 @@ depends: [
   "tcpip" {>= "8.2.0"}
   "metrics"
   "mirage-crypto-rng" {>= "1.0.0"}
+  "tls-mirage" {>= "2.0.2"}
 ]
 
 build: [

--- a/dns-stub.opam
+++ b/dns-stub.opam
@@ -8,13 +8,12 @@ bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 license: "BSD-2-Clause"
 
 depends: [
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.8.0"}
   "ocaml" {>= "4.13.0"}
   "cstruct" {>= "6.0.0"}
   "dns" {= version}
   "dns-client-mirage" {= version}
   "dns-mirage" {= version}
-  "dns-resolver" {= version}
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}

--- a/dns-stub.opam
+++ b/dns-stub.opam
@@ -14,6 +14,7 @@ depends: [
   "dns" {= version}
   "dns-client-mirage" {= version}
   "dns-mirage" {= version}
+  "dns-resolver" {= version}
   "dns-tsig" {= version}
   "dns-server" {= version}
   "duration" {>= "0.1.2"}

--- a/dns-tsig.opam
+++ b/dns-tsig.opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 license: "BSD-2-Clause"
 
 depends: [
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.8.0"}
   "ocaml" {>= "4.13.0"}
   "dns" {= version}
   "digestif" {>= "1.2.0"}

--- a/dns.opam
+++ b/dns.opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 license: "BSD-2-Clause"
 
 depends: [
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.8.0"}
   "ocaml" {>= "4.13.0"}
   "logs" "ptime"
   "fmt" {>= "0.8.8"}

--- a/dnssec.opam
+++ b/dnssec.opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 license: "BSD-2-Clause"
 
 depends: [
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.8.0"}
   "ocaml" {>= "4.13.0"}
   "dns" {= version}
   "alcotest" {with-test}

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 2.7)
+(lang dune 2.8)
 (name dns)
 (formatting disabled)

--- a/mirage/resolver/dns_resolver_mirage.mli
+++ b/mirage/resolver/dns_resolver_mirage.mli
@@ -7,25 +7,10 @@ module Make (S : Tcpip.Stack.V4V6) : sig
     :  S.t -> ?root:bool -> ?timer:int -> ?udp:bool -> ?tcp:bool -> ?tls:Tls.Config.server -> ?port:int -> ?tls_port:int
     -> Dns_resolver.t -> t
   (** [resolver stack ~root ~timer ~udp ~tcp ~tls ~port ~tls_port resolver]
-     registers a caching resolver on the provided protocols [udp], [tcp], [tls]
-     using [port] for udp and tcp (defaults to 53), [tls_port] for tls (defaults
-     to 853) using the [resolver] configuration. The [timer] is in milliseconds
-     and defaults to 500 milliseconds.*)
+      registers a caching resolver on the provided protocols [udp], [tcp], [tls]
+      using [port] for udp and tcp (defaults to 53), [tls_port] for tls (defaults
+      to 853) using the [resolver] configuration. The [timer] is in milliseconds
+      and defaults to 500 milliseconds.*)
 
-  val resolve_external : t -> Ipaddr.t * int -> string -> (int32 * string) Lwt.t
-  (** [resolve_external t (ip, port) data] resolves for [(ip, port)] the query
-      [data] and returns a pair of the minimum TTL and a response. *)
-
-  val primary_data : t -> Dns_trie.t
-  (** [primary_data t] is the DNS trie of the primary for the resolver [t]. *)
-
-  val update_primary_data : t -> Dns_trie.t -> unit
-  (** [update_primary_data t data] updates the primary for the resolver [t]
-      with the DNS trie [data]. Any 'notify's to secondaries are discarded -
-      secondary name servers are not supported in this setup. *)
-
-  val update_tls : t -> Tls.Config.server -> unit
-  (** [update_tls t tls_config] updates the tls configuration to [tls_config].
-      If the resolver wasn't already listening for TLS connections it will
-      start listening. *)
+  include module type of Dns_resolver_mirage_shared with type t := t
 end

--- a/mirage/resolver/dns_resolver_mirage_shared.mli
+++ b/mirage/resolver/dns_resolver_mirage_shared.mli
@@ -1,0 +1,20 @@
+(* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
+
+type t
+
+val resolve_external : t -> Ipaddr.t * int -> string -> (int32 * string) Lwt.t
+(** [resolve_external t (ip, port) data] resolves for [(ip, port)] the query
+    [data] and returns a pair of the minimum TTL and a response. *)
+
+val primary_data : t -> Dns_trie.t
+(** [primary_data t] is the DNS trie of the primary for the resolver [t]. *)
+
+val update_primary_data : t -> Dns_trie.t -> unit
+(** [update_primary_data t data] updates the primary for the resolver [t]
+    with the DNS trie [data]. Any 'notify's to secondaries are discarded -
+    secondary name servers are not supported in this setup. *)
+
+val update_tls : t -> Tls.Config.server -> unit
+(** [update_tls t tls_config] updates the tls configuration to [tls_config].
+    If the resolver wasn't already listening for TLS connections it will
+    start listening. *)

--- a/mirage/resolver/dune
+++ b/mirage/resolver/dune
@@ -3,7 +3,7 @@
  (public_name dns-resolver.mirage)
  (wrapped false)
  (modules dns_resolver_mirage)
- (libraries dns dns-resolver dns-server dns-mirage lwt duration mirage-sleep mirage-ptime mirage-mtime tcpip mirage-crypto-rng tls tls-mirage ca-certs-nss dns_resolver_mirage_shared))
+ (libraries dns dns-resolver dns-server dns-mirage lwt duration mirage-sleep mirage-ptime mirage-mtime tcpip mirage-crypto-rng tls tls-mirage ca-certs-nss dns-resolver.shared))
 
 (library
  (name dns_resolver_mirage_shared)

--- a/mirage/resolver/dune
+++ b/mirage/resolver/dune
@@ -2,4 +2,13 @@
  (name dns_resolver_mirage)
  (public_name dns-resolver.mirage)
  (wrapped false)
- (libraries dns dns-resolver dns-server dns-mirage lwt duration mirage-sleep mirage-ptime mirage-mtime tcpip mirage-crypto-rng tls tls-mirage ca-certs-nss))
+ (modules dns_resolver_mirage)
+ (libraries dns dns-resolver dns-server dns-mirage lwt duration mirage-sleep mirage-ptime mirage-mtime tcpip mirage-crypto-rng tls tls-mirage ca-certs-nss dns_resolver_mirage_shared))
+
+(library
+ (name dns_resolver_mirage_shared)
+ (public_name dns-resolver.shared)
+ (wrapped false)
+ (modules dns_resolver_mirage_shared)
+ (modules_without_implementation dns_resolver_mirage_shared)
+ (libraries ipaddr dns-server tcpip tls))

--- a/mirage/stub/dns_stub_mirage.ml
+++ b/mirage/stub/dns_stub_mirage.ml
@@ -250,11 +250,11 @@ module Make (S : Tcpip.Stack.V4V6) = struct
   let handle t proto ip buf =
     match Packet.decode buf with
     | Error err ->
-      (* TODO send FormErr back *)
       Log.err (fun m -> m "couldn't decode %a" Packet.pp_err err);
       Dns_resolver_metrics.response_metric 0L;
       Dns_resolver_metrics.resolver_stats `Error;
-      Lwt.return None
+      let answer = Packet.raw_error buf Rcode.FormErr in
+      Lwt.return (Option.map (fun r -> 0l, r) answer)
     | Ok packet ->
       Dns_resolver_metrics.resolver_stats `Queries;
       let start = Mirage_mtime.elapsed_ns () in

--- a/mirage/stub/dns_stub_mirage.mli
+++ b/mirage/stub/dns_stub_mirage.mli
@@ -5,14 +5,14 @@ module Make (S : Tcpip.Stack.V4V6) : sig
 
   module H : Happy_eyeballs_mirage.S with type stack = S.t and type flow = S.TCP.flow
 
-
-  val create : ?cache_size:int -> ?edns:[ `Auto | `Manual of Dns.Edns.t | `None ] ->
+  val create : ?cache_size:int -> ?udp:bool -> ?tcp:bool -> ?port:int ->
+    ?edns:[ `Auto | `Manual of Dns.Edns.t | `None ] ->
     ?nameservers:string list ->
     ?timeout:int64 ->
     ?on_update:(old:Dns_trie.t -> ?authenticated_key:[ `raw ] Domain_name.t ->
                 update_source:Ipaddr.t -> Dns_trie.t -> unit Lwt.t) ->
     Dns_server.Primary.s -> happy_eyeballs:H.t -> S.t -> t Lwt.t
-  (* with respect to resolver, lacking: udp tcp port tls tls_port *)
+  (* with respect to resolver, lacking: tls tls_port *)
   (** [create ~cache_size ~edns ~nameservers ~timeout ~on_update server ~happy_eyeballs stack]
       registers a stub resolver on the provided protocols [udp], [tcp], [tls]
       using [port] for udp and tcp (defaults to 53), [tls_port] for tls (defaults

--- a/mirage/stub/dns_stub_mirage.mli
+++ b/mirage/stub/dns_stub_mirage.mli
@@ -1,0 +1,38 @@
+(* (c) 2025 Hannes Mehnert, all rights reserved *)
+
+module Make (S : Tcpip.Stack.V4V6) : sig
+  type t
+
+  module H : Happy_eyeballs_mirage.S with type stack = S.t and type flow = S.TCP.flow
+
+
+  val create : ?cache_size:int -> ?edns:[ `Auto | `Manual of Dns.Edns.t | `None ] ->
+    ?nameservers:string list ->
+    ?timeout:int64 ->
+    ?on_update:(old:Dns_trie.t -> ?authenticated_key:[ `raw ] Domain_name.t ->
+                update_source:Ipaddr.t -> Dns_trie.t -> unit Lwt.t) ->
+    Dns_server.Primary.s -> happy_eyeballs:H.t -> S.t -> t Lwt.t
+  (* with respect to resolver, lacking: udp tcp port tls tls_port *)
+  (** [create ~cache_size ~edns ~nameservers ~timeout ~on_update server ~happy_eyeballs stack]
+     registers a stub resolver on the provided protocols [udp], [tcp], [tls]
+     using [port] for udp and tcp (defaults to 53), [tls_port] for tls (defaults
+     to 853) using the [resolver] configuration. The [timer] is in milliseconds
+     and defaults to 500 milliseconds.*)
+
+  val resolve_external : t -> Ipaddr.t * int -> string -> (int32 * string) Lwt.t
+  (** [resolve_external t (ip, port) data] resolves for [(ip, port)] the query
+      [data] and returns a pair of the minimum TTL and a response. *)
+
+  val primary_data : t -> Dns_trie.t
+  (** [primary_data t] is the DNS trie of the primary for the resolver [t]. *)
+
+  val update_primary_data : t -> Dns_trie.t -> unit
+  (** [update_primary_data t data] updates the primary for the resolver [t]
+      with the DNS trie [data]. Any 'notify's to secondaries are discarded -
+      secondary name servers are not supported in this setup. *)
+
+  val update_tls : t -> Tls.Config.server -> unit
+  (** [update_tls t tls_config] updates the tls configuration to [tls_config].
+      If the resolver wasn't already listening for TLS connections it will
+      start listening. *)
+end

--- a/mirage/stub/dns_stub_mirage.mli
+++ b/mirage/stub/dns_stub_mirage.mli
@@ -6,13 +6,13 @@ module Make (S : Tcpip.Stack.V4V6) : sig
   module H : Happy_eyeballs_mirage.S with type stack = S.t and type flow = S.TCP.flow
 
   val create : ?cache_size:int -> ?udp:bool -> ?tcp:bool -> ?port:int ->
+    ?tls:Tls.Config.server -> ?tls_port:int ->
     ?edns:[ `Auto | `Manual of Dns.Edns.t | `None ] ->
     ?nameservers:string list ->
     ?timeout:int64 ->
     ?on_update:(old:Dns_trie.t -> ?authenticated_key:[ `raw ] Domain_name.t ->
                 update_source:Ipaddr.t -> Dns_trie.t -> unit Lwt.t) ->
     Dns_server.Primary.s -> happy_eyeballs:H.t -> S.t -> t Lwt.t
-  (* with respect to resolver, lacking: tls tls_port *)
   (** [create ~cache_size ~edns ~nameservers ~timeout ~on_update server ~happy_eyeballs stack]
       registers a stub resolver on the provided protocols [udp], [tcp], [tls]
       using [port] for udp and tcp (defaults to 53), [tls_port] for tls (defaults

--- a/mirage/stub/dns_stub_mirage.mli
+++ b/mirage/stub/dns_stub_mirage.mli
@@ -14,25 +14,10 @@ module Make (S : Tcpip.Stack.V4V6) : sig
     Dns_server.Primary.s -> happy_eyeballs:H.t -> S.t -> t Lwt.t
   (* with respect to resolver, lacking: udp tcp port tls tls_port *)
   (** [create ~cache_size ~edns ~nameservers ~timeout ~on_update server ~happy_eyeballs stack]
-     registers a stub resolver on the provided protocols [udp], [tcp], [tls]
-     using [port] for udp and tcp (defaults to 53), [tls_port] for tls (defaults
-     to 853) using the [resolver] configuration. The [timer] is in milliseconds
-     and defaults to 500 milliseconds.*)
+      registers a stub resolver on the provided protocols [udp], [tcp], [tls]
+      using [port] for udp and tcp (defaults to 53), [tls_port] for tls (defaults
+      to 853) using the [resolver] configuration. The [timer] is in milliseconds
+      and defaults to 500 milliseconds.*)
 
-  val resolve_external : t -> Ipaddr.t * int -> string -> (int32 * string) Lwt.t
-  (** [resolve_external t (ip, port) data] resolves for [(ip, port)] the query
-      [data] and returns a pair of the minimum TTL and a response. *)
-
-  val primary_data : t -> Dns_trie.t
-  (** [primary_data t] is the DNS trie of the primary for the resolver [t]. *)
-
-  val update_primary_data : t -> Dns_trie.t -> unit
-  (** [update_primary_data t data] updates the primary for the resolver [t]
-      with the DNS trie [data]. Any 'notify's to secondaries are discarded -
-      secondary name servers are not supported in this setup. *)
-
-  val update_tls : t -> Tls.Config.server -> unit
-  (** [update_tls t tls_config] updates the tls configuration to [tls_config].
-      If the resolver wasn't already listening for TLS connections it will
-      start listening. *)
+  include module type of Dns_resolver_mirage_shared with type t := t
 end

--- a/mirage/stub/dns_stub_mirage.mli
+++ b/mirage/stub/dns_stub_mirage.mli
@@ -3,7 +3,12 @@
 module Make (S : Tcpip.Stack.V4V6) : sig
   type t
 
-  module H : Happy_eyeballs_mirage.S with type stack = S.t and type flow = S.TCP.flow
+  module H : sig
+    include Happy_eyeballs_mirage.S with type stack = S.t and type flow = S.TCP.flow
+    val connect_device : ?aaaa_timeout:int64 -> ?connect_delay:int64 ->
+      ?connect_timeout:int64 -> ?resolve_timeout:int64 -> ?resolve_retries:int ->
+      ?timer_interval:int64 -> ?getaddrinfo:getaddrinfo -> stack -> t Lwt.t
+  end
 
   val create : ?cache_size:int -> ?udp:bool -> ?tcp:bool -> ?port:int ->
     ?tls:Tls.Config.server -> ?tls_port:int ->

--- a/mirage/stub/dune
+++ b/mirage/stub/dune
@@ -2,4 +2,4 @@
  (name dns_stub_mirage)
  (public_name dns-stub.mirage)
  (wrapped false)
- (libraries dns dns-server dns-tsig metrics dns_resolver_shared dns-mirage dns-client-mirage lwt mirage-ptime tcpip mirage-crypto-rng))
+ (libraries dns dns-server dns-tsig metrics dns_resolver_shared dns_resolver.shared dns-mirage dns-client-mirage lwt mirage-ptime tcpip mirage-crypto-rng))

--- a/mirage/stub/dune
+++ b/mirage/stub/dune
@@ -2,4 +2,4 @@
  (name dns_stub_mirage)
  (public_name dns-stub.mirage)
  (wrapped false)
- (libraries dns dns-server dns-tsig metrics dns-resolver dns-mirage dns-client-mirage lwt mirage-ptime tcpip mirage-crypto-rng))
+ (libraries dns dns-server dns-tsig metrics dns_resolver_shared dns-mirage dns-client-mirage lwt mirage-ptime tcpip mirage-crypto-rng))

--- a/mirage/stub/dune
+++ b/mirage/stub/dune
@@ -2,4 +2,4 @@
  (name dns_stub_mirage)
  (public_name dns-stub.mirage)
  (wrapped false)
- (libraries dns dns-server dns-tsig metrics dns_resolver_shared dns-resolver.shared dns-mirage dns-client-mirage lwt mirage-ptime tcpip mirage-crypto-rng))
+ (libraries dns dns-server dns-tsig metrics dns_resolver_shared dns-resolver.shared dns-mirage dns-client-mirage lwt mirage-ptime tcpip mirage-crypto-rng tls-mirage))

--- a/mirage/stub/dune
+++ b/mirage/stub/dune
@@ -2,4 +2,4 @@
  (name dns_stub_mirage)
  (public_name dns-stub.mirage)
  (wrapped false)
- (libraries dns dns-server dns-tsig metrics dns_resolver_shared dns_resolver.shared dns-mirage dns-client-mirage lwt mirage-ptime tcpip mirage-crypto-rng))
+ (libraries dns dns-server dns-tsig metrics dns_resolver_shared dns-resolver.shared dns-mirage dns-client-mirage lwt mirage-ptime tcpip mirage-crypto-rng))

--- a/resolver/dns_block.ml
+++ b/resolver/dns_block.ml
@@ -1,0 +1,100 @@
+open Dns
+
+let src = Logs.Src.create "dns_block" ~doc:"DNS block"
+module Log = (val Logs.src_log src : Logs.LOG)
+
+let nameserver =
+  let lh = Domain_name.of_string_exn "localhost"
+  and bl = Domain_name.of_string_exn "blocked"
+  in
+  fun ns -> Domain_name.equal ns lh || Domain_name.equal ns bl
+
+let ipv4 =
+  let lh = Ipaddr.V4.(Set.singleton localhost)
+  and any = Ipaddr.V4.(Set.singleton any)
+  in
+  fun ipv4s -> Ipaddr.V4.Set.equal ipv4s lh || Ipaddr.V4.Set.equal ipv4s any
+
+let ipv6 =
+  let lh = Ipaddr.V6.(Set.singleton localhost)
+  and un = Ipaddr.V6.(Set.singleton unspecified)
+  in
+  fun ipv6s -> Ipaddr.V6.Set.equal ipv6s lh || Ipaddr.V6.Set.equal ipv6s un
+
+let likely reply =
+  (* HACK! We assume blocked domains have a certain shape. *)
+  let blocked_soa auth =
+    Domain_name.Map.cardinal auth > 0 &&
+    Domain_name.Map.for_all (fun _domain rr ->
+        match Rr_map.find Rr_map.Soa rr with
+        | None -> false
+        | Some soa -> nameserver soa.nameserver)
+      auth
+  in
+  match reply.Packet.data with
+  | `Answer (answ, _auth) ->
+    Domain_name.Map.for_all
+      (fun _domain rr ->
+         Rr_map.for_all
+           (function
+             | Rr_map.B (Rr_map.A, (_, ips)) -> ipv4 ips
+             | Rr_map.B (Rr_map.Aaaa, (_, ips)) -> ipv6 ips
+             | _ -> false)
+           rr)
+      answ
+  | `Rcode_error (Rcode.NXDomain, _, Some (_answ, auth)) -> blocked_soa auth
+  | _ -> false
+
+let reason reply =
+  let find_soa_hostmaster rr =
+    match Rr_map.find Rr_map.Soa rr with
+    | None -> None
+    | Some soa ->
+      if nameserver soa.Soa.nameserver then
+        Some (Domain_name.to_string soa.Soa.hostmaster)
+      else
+        None
+  in
+  let find_soa_hostmaster_in_domain_map map =
+    Domain_name.Map.fold (fun _domain rr acc ->
+        match acc, find_soa_hostmaster rr with
+        | None, x -> x
+        | Some x, None -> Some x
+        | Some x, Some y ->
+          if not (String.equal x y) then
+            Log.info (fun m -> m "finding blocklist resulted in %S and %S, using the first" x y);
+          Some x) map None
+  in
+  let find_soa_hostmaster_in_reply answer authority =
+    match find_soa_hostmaster_in_domain_map answer, find_soa_hostmaster_in_domain_map authority with
+    | None, x -> x
+    | Some x, None -> Some x
+    | Some x, Some y ->
+      if not (String.equal x y) then
+        Log.info (fun m -> m "finding blocklist resulted in %S (answer) and %S (authority), using the first" x y);
+      Some x
+  in
+  let r =
+    match reply.Packet.data with
+    | `Answer (answ, auth) -> find_soa_hostmaster_in_reply answ auth
+    | `Rcode_error (Rcode.NXDomain, _, Some (answ, auth)) ->
+      find_soa_hostmaster_in_reply answ auth
+    | _ -> None
+  in
+  Option.map (fun reason -> "appears in blocklist " ^ reason) r
+
+let edns reply =
+  if likely reply then
+    (* After guessing that a domain is blocked we add [`Filtered] extended error
+       code and emit a [`Blocked] metrics event. *)
+    let reason = reason reply in
+    match reply.edns with
+    | None ->
+      Some (Edns.create ~extended_error:(`Blocked, reason) ())
+    | Some ({ Edns.extensions = []; extended_rcode; version; dnssec_ok; payload_size }) ->
+      Some (Edns.create ~extended_error:(`Blocked, reason) ~extended_rcode ~version ~dnssec_ok ~payload_size ())
+    | Some edns ->
+      Log.warn (fun m -> m "don't know how to extend edns to add extended error; not doing anything:@ %a" Edns.pp edns);
+      Some edns
+  else
+    None

--- a/resolver/dns_resolver.ml
+++ b/resolver/dns_resolver.ml
@@ -273,86 +273,6 @@ let scrub_it t proto zone edns ts ~signed qtype p =
     Log.warn (fun m -> m "NS didn't like us %a" Rcode.pp e) ;
     `Try_another_ns
 
-let blocked_nameserver =
-  let lh = Domain_name.of_string_exn "localhost"
-  and bl = Domain_name.of_string_exn "blocked"
-  in
-  fun ns -> Domain_name.equal ns lh || Domain_name.equal ns bl
-
-let blocked_ipv4 =
-  let lh = Ipaddr.V4.(Set.singleton localhost)
-  and any = Ipaddr.V4.(Set.singleton any)
-  in
-  fun ipv4s -> Ipaddr.V4.Set.equal ipv4s lh || Ipaddr.V4.Set.equal ipv4s any
-
-let blocked_ipv6 =
-  let lh = Ipaddr.V6.(Set.singleton localhost)
-  and un = Ipaddr.V6.(Set.singleton unspecified)
-  in
-  fun ipv6s -> Ipaddr.V6.Set.equal ipv6s lh || Ipaddr.V6.Set.equal ipv6s un
-
-let likely_blocked reply =
-  (* HACK! We assume blocked domains have a certain shape. *)
-  let blocked_soa auth =
-    Domain_name.Map.cardinal auth > 0 &&
-    Domain_name.Map.for_all (fun _domain rr ->
-        match Rr_map.find Rr_map.Soa rr with
-        | None -> false
-        | Some soa -> blocked_nameserver soa.nameserver)
-      auth
-  in
-  match reply.Packet.data with
-  | `Answer (answ, _auth) ->
-    Domain_name.Map.for_all
-      (fun _domain rr ->
-         Rr_map.for_all
-           (function
-             | Rr_map.B (Rr_map.A, (_, ips)) -> blocked_ipv4 ips
-             | Rr_map.B (Rr_map.Aaaa, (_, ips)) -> blocked_ipv6 ips
-             | _ -> false)
-           rr)
-      answ
-  | `Rcode_error (Rcode.NXDomain, _, Some (_answ, auth)) -> blocked_soa auth
-  | _ -> false
-
-let blocking_reason reply =
-  let find_soa_hostmaster rr =
-    match Rr_map.find Rr_map.Soa rr with
-    | None -> None
-    | Some soa ->
-      if blocked_nameserver soa.Soa.nameserver then
-        Some (Domain_name.to_string soa.Soa.hostmaster)
-      else
-        None
-  in
-  let find_soa_hostmaster_in_domain_map map =
-    Domain_name.Map.fold (fun _domain rr acc ->
-        match acc, find_soa_hostmaster rr with
-        | None, x -> x
-        | Some x, None -> Some x
-        | Some x, Some y ->
-          if not (String.equal x y) then
-            Log.info (fun m -> m "finding blocklist resulted in %S and %S, using the first" x y);
-          Some x) map None
-  in
-  let find_soa_hostmaster_in_reply answer authority =
-    match find_soa_hostmaster_in_domain_map answer, find_soa_hostmaster_in_domain_map authority with
-    | None, x -> x
-    | Some x, None -> Some x
-    | Some x, Some y ->
-      if not (String.equal x y) then
-        Log.info (fun m -> m "finding blocklist resulted in %S (answer) and %S (authority), using the first" x y);
-      Some x
-  in
-  let r =
-    match reply.Packet.data with
-    | `Answer (answ, auth) -> find_soa_hostmaster_in_reply answ auth
-    | `Rcode_error (Rcode.NXDomain, _, Some (answ, auth)) ->
-      find_soa_hostmaster_in_reply answ auth
-    | _ -> None
-  in
-  Option.map (fun reason -> "appears in blocklist " ^ reason) r
-
 let handle_primary t now ts proto sender sport packet _request buf =
   (* makes only sense to ask primary for query=true since we'll never issue questions from primary *)
   let handle_inner name =
@@ -364,24 +284,11 @@ let handle_primary t now ts proto sender sport packet _request buf =
       if Packet.Flags.mem `Authoritative (snd reply.header) then begin
         Log.debug (fun m -> m "authoritative reply %a" Packet.pp reply) ;
         let reply =
-          if likely_blocked reply then
-            (* After guessing that a domain is blocked we add [`Filtered]
-               extended error code and emit a [`Blocked] metrics event. *)
-            let edns =
-              let reason = blocking_reason reply in
-              match reply.edns with
-              | None ->
-                Some (Edns.create ~extended_error:(`Blocked, reason) ())
-              | Some ({ Edns.extensions = []; extended_rcode; version; dnssec_ok; payload_size }) ->
-                Some (Edns.create ~extended_error:(`Blocked, reason) ~extended_rcode ~version ~dnssec_ok ~payload_size ())
-              | Some edns ->
-                Log.warn (fun m -> m "don't know how to extend edns to add extended error; not doing anything:@ %a" Edns.pp edns);
-                Some edns
-            in
+          match Dns_block.edns reply with
+          | None -> reply
+          | Some edns ->
             resolver_stats `Blocked;
-            Dns.Packet.with_edns reply edns
-          else
-            reply
+            Dns.Packet.with_edns reply (Some edns)
         in
         let r = Packet.encode proto reply in
         let ttl = Packet.minimum_ttl reply.data in

--- a/resolver/dns_resolver_metrics.ml
+++ b/resolver/dns_resolver_metrics.ml
@@ -1,0 +1,18 @@
+let resolver_stats =
+  let f = function
+    | `Error -> "error"
+    | `Queries -> "queries"
+    | `Blocked -> "blocked"
+    | `Clients -> "clients"
+  in
+  let src = Dns.counter_metrics ~f "dns-resolver" in
+  (fun r -> Metrics.add src (fun x -> x) (fun d -> d r))
+
+let response_metric =
+  let store = ref (0L, 0L) in
+  let data dp =
+    store := (Int64.succ (fst !store), Int64.add dp (snd !store));
+    Metrics.Data.v [ Metrics.uint "mean response" (Duration.to_ms (Int64.div (snd !store) (fst !store))) ]
+  in
+  let src = Metrics.Src.v ~tags:Metrics.Tags.[] ~data "dns-resolver-timings" in
+  (fun dp -> Metrics.add src (fun x -> x) (fun d -> d dp))

--- a/resolver/dns_resolver_metrics.mli
+++ b/resolver/dns_resolver_metrics.mli
@@ -1,0 +1,3 @@
+val resolver_stats : [ `Blocked | `Clients | `Error | `Queries ] -> unit
+
+val response_metric : int64 -> unit

--- a/resolver/dune
+++ b/resolver/dune
@@ -4,4 +4,12 @@
  (instrumentation
   (backend bisect_ppx))
  (wrapped false)
- (libraries dns dns.cache dns-server lru duration randomconv dnssec logs))
+ (modules dns_resolver dns_resolver_utils dns_resolver_cache)
+ (libraries dns dns.cache dns-server lru duration randomconv dnssec logs dns_resolver_shared))
+
+(library
+  (name dns_resolver_shared)
+  (package dns-resolver)
+  (wrapped false)
+  (modules dns_resolver_root dns_block)
+  (libraries dns dns-server))

--- a/resolver/dune
+++ b/resolver/dune
@@ -11,5 +11,5 @@
   (name dns_resolver_shared)
   (package dns-resolver)
   (wrapped false)
-  (modules dns_resolver_root dns_block)
-  (libraries dns dns-server))
+  (modules dns_resolver_root dns_block dns_resolver_metrics)
+  (libraries dns dns-server metrics))


### PR DESCRIPTION
This allows us to use the stub resolver in DNSvizor.