### PR TITLE
Expose a module type instead of a module shared between dns-mirage-{resolver,stub}

### DIFF
--- a/mirage/resolver/dns_resolver_mirage.mli
+++ b/mirage/resolver/dns_resolver_mirage.mli
@@ -12,5 +12,5 @@ module Make (S : Tcpip.Stack.V4V6) : sig
       to 853) using the [resolver] configuration. The [timer] is in milliseconds
       and defaults to 500 milliseconds.*)
 
-  include module type of Dns_resolver_mirage_shared with type t := t
+  include Dns_resolver_mirage_shared.S with type t := t
 end

--- a/mirage/resolver/dns_resolver_mirage_shared.ml
+++ b/mirage/resolver/dns_resolver_mirage_shared.ml
@@ -1,0 +1,10 @@
+(* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
+
+module type S = sig
+  type t
+  
+  val resolve_external : t -> Ipaddr.t * int -> string -> (int32 * string) Lwt.t
+  val primary_data : t -> Dns_trie.t
+  val update_primary_data : t -> Dns_trie.t -> unit
+  val update_tls : t -> Tls.Config.server -> unit
+end

--- a/mirage/resolver/dns_resolver_mirage_shared.mli
+++ b/mirage/resolver/dns_resolver_mirage_shared.mli
@@ -1,20 +1,22 @@
 (* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
 
-type t
-
-val resolve_external : t -> Ipaddr.t * int -> string -> (int32 * string) Lwt.t
-(** [resolve_external t (ip, port) data] resolves for [(ip, port)] the query
-    [data] and returns a pair of the minimum TTL and a response. *)
-
-val primary_data : t -> Dns_trie.t
-(** [primary_data t] is the DNS trie of the primary for the resolver [t]. *)
-
-val update_primary_data : t -> Dns_trie.t -> unit
-(** [update_primary_data t data] updates the primary for the resolver [t]
-    with the DNS trie [data]. Any 'notify's to secondaries are discarded -
-    secondary name servers are not supported in this setup. *)
-
-val update_tls : t -> Tls.Config.server -> unit
-(** [update_tls t tls_config] updates the tls configuration to [tls_config].
-    If the resolver wasn't already listening for TLS connections it will
-    start listening. *)
+module type S = sig
+  type t
+  
+  val resolve_external : t -> Ipaddr.t * int -> string -> (int32 * string) Lwt.t
+  (** [resolve_external t (ip, port) data] resolves for [(ip, port)] the query
+      [data] and returns a pair of the minimum TTL and a response. *)
+  
+  val primary_data : t -> Dns_trie.t
+  (** [primary_data t] is the DNS trie of the primary for the resolver [t]. *)
+  
+  val update_primary_data : t -> Dns_trie.t -> unit
+  (** [update_primary_data t data] updates the primary for the resolver [t]
+      with the DNS trie [data]. Any 'notify's to secondaries are discarded -
+      secondary name servers are not supported in this setup. *)
+  
+  val update_tls : t -> Tls.Config.server -> unit
+  (** [update_tls t tls_config] updates the tls configuration to [tls_config].
+      If the resolver wasn't already listening for TLS connections it will
+      start listening. *)
+end

--- a/mirage/resolver/dune
+++ b/mirage/resolver/dune
@@ -3,12 +3,11 @@
  (public_name dns-resolver.mirage)
  (wrapped false)
  (modules dns_resolver_mirage)
- (libraries dns dns-resolver dns-server dns-mirage lwt duration mirage-sleep mirage-ptime mirage-mtime tcpip mirage-crypto-rng tls tls-mirage ca-certs-nss dns-resolver.shared))
+ (libraries dns dns-resolver dns-server dns-mirage lwt duration mirage-sleep mirage-ptime mirage-mtime tcpip mirage-crypto-rng tls tls-mirage ca-certs-nss dns-resolver.mirage.shared))
 
 (library
  (name dns_resolver_mirage_shared)
- (public_name dns-resolver.shared)
+ (public_name dns-resolver.mirage.shared)
  (wrapped false)
  (modules dns_resolver_mirage_shared)
- (modules_without_implementation dns_resolver_mirage_shared)
  (libraries ipaddr dns-server tcpip tls))

--- a/mirage/stub/dns_stub_mirage.mli
+++ b/mirage/stub/dns_stub_mirage.mli
@@ -24,5 +24,5 @@ module Make (S : Tcpip.Stack.V4V6) : sig
       to 853) using the [resolver] configuration. The [timer] is in milliseconds
       and defaults to 500 milliseconds.*)
 
-  include module type of Dns_resolver_mirage_shared with type t := t
+  include Dns_resolver_mirage_shared.S with type t := t
 end

--- a/mirage/stub/dune
+++ b/mirage/stub/dune
@@ -2,4 +2,4 @@
  (name dns_stub_mirage)
  (public_name dns-stub.mirage)
  (wrapped false)
- (libraries dns dns-server dns-tsig metrics dns_resolver_shared dns-resolver.shared dns-mirage dns-client-mirage lwt mirage-ptime tcpip mirage-crypto-rng tls-mirage))
+ (libraries dns dns-server dns-tsig metrics dns_resolver_shared dns-resolver.mirage.shared dns-mirage dns-client-mirage lwt mirage-ptime tcpip mirage-crypto-rng tls-mirage))

--- a/resolver/dns_resolver_shared.ml
+++ b/resolver/dns_resolver_shared.ml
@@ -1,0 +1,3 @@
+module Root = Dns_resolver_root
+module Metrics = Dns_resolver_metrics
+module Block = Dns_block

--- a/resolver/dune
+++ b/resolver/dune
@@ -9,7 +9,7 @@
 
 (library
   (name dns_resolver_shared)
-  (package dns-resolver)
+  (public_name dns-resolver.shared)
   (wrapped false)
-  (modules dns_resolver_root dns_block dns_resolver_metrics)
+  (modules dns_resolver_shared dns_resolver_root dns_block dns_resolver_metrics)
   (libraries dns dns-server metrics))


### PR DESCRIPTION
And expose into dns-resolver.shared few modules such as `Dns_root`, `Dns_metrics` or `Dns_block`.

This PR proposes another layout of the `ocaml-dns` distribution (to fix #395) where we expose few useful elements for the user with the `dns-resolver.shared` package (roots, metrics and how to block). It provides a new package `dns-resolver.mirage.shared` which exposes a signature (and can be re-used into unikernels such as DNSVizor) which is shared between `dns-{resolver,stub}-mirage`.

By this way, we don't have `__private__` sub-libraries and elements which were exposed before are still available. It breaks obviously the API. I'm not sure about name convention.