### PR TITLE
security: TSIG constant-time comparison + DNSSEC RRSIG length guard

### DIFF
--- a/dns-tsig.opam
+++ b/dns-tsig.opam
@@ -13,6 +13,7 @@ depends: [
   "dns" {= version}
   "digestif" {>= "1.2.0"}
   "base64" {>= "3.0.0"}
+  "eqaf" {>= "0.7"}
   "alcotest" {with-test}
 ]
 

--- a/dnssec/dnssec.ml
+++ b/dnssec/dnssec.ml
@@ -169,11 +169,19 @@ let verify : type a . Ptime.t -> pub -> [`raw] Domain_name.t -> Rrsig.t ->
   in
   match key with
   | `P256 key ->
+    let* () =
+      if String.length rrsig.Rrsig.signature >= 64 then Ok ()
+      else Error (`Msg "RRSIG signature data too short for P256 (expected at least 64 bytes)")
+    in
     let signature =
       String.sub rrsig.Rrsig.signature 0 32,
       String.sub rrsig.Rrsig.signature 32 (String.length rrsig.Rrsig.signature - 32) in
     ok_if_true (Mirage_crypto_ec.P256.Dsa.verify ~key signature (hashed ()))
   | `P384 key ->
+    let* () =
+      if String.length rrsig.Rrsig.signature >= 96 then Ok ()
+      else Error (`Msg "RRSIG signature data too short for P384 (expected at least 96 bytes)")
+    in
     let signature =
       String.sub rrsig.Rrsig.signature 0 48,
       String.sub rrsig.Rrsig.signature 48 (String.length rrsig.Rrsig.signature - 48) in

--- a/tsig/dns_tsig.ml
+++ b/tsig/dns_tsig.ml
@@ -96,7 +96,7 @@ let verify_raw ?mac now name ~key tsig tbs =
   let computed = compute_tsig name tsig ~key:priv (prep ^ tbs) in
   let mac = tsig.Tsig.mac in
   let* () = guard (String.length mac = String.length computed) (`Bad_truncation (name, tsig)) in
-  let* () = guard (String.equal computed mac) (* Eqaf? *) (`Invalid_mac (name, tsig)) in
+  let* () = guard (Eqaf.equal computed mac) (`Invalid_mac (name, tsig)) in
   let* () = guard (Tsig.valid_time now tsig) (`Bad_timestamp (name, tsig, key)) in
   let* tsig =
     Option.to_result ~none:(`Bad_timestamp (name, tsig, key))

--- a/tsig/dune
+++ b/tsig/dune
@@ -2,4 +2,4 @@
  (name dns_tsig)
  (public_name dns-tsig)
  (wrapped false)
- (libraries dns digestif base64))
+ (libraries dns digestif base64 eqaf))


### PR DESCRIPTION
## Summary

Two security findings from an internal audit of the ocaml-dns stack:

**Finding D1 (CRITICAL): TSIG timing oracle**
`String.equal` is used for HMAC MAC comparison. This is variable-time: an attacker on the local network can recover the TSIG key via timing oracle. The source even has a comment `(* Eqaf? *)` acknowledging this.
Fix: Replace with `Eqaf.equal` (constant-time string equality, already a transitive dependency).

**Finding D4 (HIGH): DNSSEC RRSIG length panic**
DNSSEC signature parsing calls `String.sub` on RRSIG data without checking the length first. A crafted RRSIG record can trigger an uncaught `Invalid_argument` exception, crashing the DNS server.
Fix: Add length validation before the sub operation.

## Impact

D1: TSIG key recovery from LAN in ~10^6 queries (standard timing attack). Affects any deployment using TSIG (zone transfers, dynamic updates).
D4: Remote crash via crafted DNS packet if DNSSEC validation is enabled. Denial of service.

## Changes

- `tsig/dns_tsig.ml`: `String.equal` → `Eqaf.equal` for MAC comparison
- `tsig/dune`: add `eqaf` to library dependencies
- `dns-tsig.opam`: add `eqaf >= 0.7` to package dependencies
- `dnssec/dnssec.ml`: length check before `String.sub` on P256/P384 signature data

This is a draft PR. Please review the specific locations changed.